### PR TITLE
adding rule to throw an error when naturalValue is an array with undefined values

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -120,6 +120,11 @@ class DicomMetaDictionary {
         let value = naturalValue;
         if (!Array.isArray(value)) {
             value = [value];
+        }else{
+          const thereIsUndefinedValues = naturalValue.filter(item => item !== undefined).length > 0;
+          if(thereIsUndefinedValues){
+            throw new Error("There are undefined values at the array naturalValue in DicomMetaDictionary.denaturalizeValue");
+          }
         }
         value = value.map(entry =>
             entry.constructor.name == "Number" ? String(entry) : entry

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -121,7 +121,7 @@ class DicomMetaDictionary {
         if (!Array.isArray(value)) {
             value = [value];
         }else{
-          const thereIsUndefinedValues = naturalValue.filter(item => item !== undefined).length > 0;
+          const thereIsUndefinedValues = naturalValue.some(item => item === undefined);
           if(thereIsUndefinedValues){
             throw new Error("There are undefined values at the array naturalValue in DicomMetaDictionary.denaturalizeValue");
           }


### PR DESCRIPTION
### What
It was included a new rule to throw an error when there is at least one undefined value under the natural values if it is an array

### Why
When this situation occurs, the `denaturalizeValue` method fails ungraceful:
`Uncaught TypeError: Cannot read property 'constructor' of undefined`

This PR is related to issue https://github.com/dcmjs-org/dcmjs/issues/42