### PR TITLE
replacing scoord to scoord3d and adding toolType in Polyline

### DIFF
--- a/src/adapters/DICOMMicroscopyViewer/MeasurementReport.js
+++ b/src/adapters/DICOMMicroscopyViewer/MeasurementReport.js
@@ -29,18 +29,18 @@ export default class MeasurementReport {
         // Input is all ROIS returned via viewer.getALLROIs()
         // let report = MeasurementReport.generateReport(viewer.getAllROIs());
 
-        // Sort and split into arrays by scoord.graphicType
+        // Sort and split into arrays by scoord3d.graphicType
         const measurementsByGraphicType = {};
         rois.forEach(roi => {
-            const graphicType = roi.scoord.graphicType;
+            const graphicType = roi.scoord3d.graphicType;
             // adding z coord as 0
-            roi.scoord.coordinates.map(coord => coord.push(0));
+            roi.scoord3d.coordinates.map(coord => coord.push(0));
 
             if (!measurementsByGraphicType[graphicType]) {
                 measurementsByGraphicType[graphicType] = [];
             }
 
-            measurementsByGraphicType[graphicType].push(roi.scoord);
+            measurementsByGraphicType[graphicType].push(roi.scoord3d);
         });
 
         // For each measurement, get the utility arguments using the adapter, and create TID300 Measurement

--- a/src/adapters/DICOMMicroscopyViewer/Polyline.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polyline.js
@@ -1,49 +1,52 @@
-import MeasurementReport from './MeasurementReport.js';
-import TID300Polyline from '../../utilities/TID300/Polyline';
+import MeasurementReport from "./MeasurementReport.js";
+import TID300Polyline from "../../utilities/TID300/Polyline";
 
 class Polyline {
-  constructor() {
-  }
+    constructor() {}
 
-  static measurementContentToLengthState(groupItemContent) {
-    const lengthContent = groupItemContent.ContentSequence;
-    const { ReferencedSOPSequence } = lengthContent.ContentSequence;
-    const { ReferencedSOPInstanceUID, ReferencedFrameNumber } = ReferencedSOPSequence
-    const lengthState = {
-      sopInstanceUid: ReferencedSOPInstanceUID,
-      frameIndex: ReferencedFrameNumber || 0,
-      length: groupItemContent.MeasuredValueSequence.NumericValue,
-    };
+    static measurementContentToLengthState(groupItemContent) {
+        const lengthContent = groupItemContent.ContentSequence;
+        const { ReferencedSOPSequence } = lengthContent.ContentSequence;
+        const {
+            ReferencedSOPInstanceUID,
+            ReferencedFrameNumber
+        } = ReferencedSOPSequence;
+        const lengthState = {
+            sopInstanceUid: ReferencedSOPInstanceUID,
+            frameIndex: ReferencedFrameNumber || 0,
+            length: groupItemContent.MeasuredValueSequence.NumericValue
+        };
 
-    // FROM DICOM TO dicom-microscopy-viewer format
+        // FROM DICOM TO dicom-microscopy-viewer format
 
-    return lengthState;
-  }
-
-  // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
-  static getMeasurementData(measurementContent) {
-    return measurementContent.map(Length.measurementContentToLengthState);
-  }
-
-  // Expects a Polyline scoord from dicom-microscopy-viewer? Check arguments?
-  static getTID300RepresentationArguments(scoord) {
-    if (scoord.graphicType !== 'POLYLINE') {
-      throw new Error('We expected a POLYLINE graphicType');
+        return lengthState;
     }
 
-    const points = scoord.graphicData;
-    const lengths = 1// scoord.distances[0];
+    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
+    static getMeasurementData(measurementContent) {
+        return measurementContent.map(Length.measurementContentToLengthState);
+    }
 
-    // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+    // Expects a Polyline scoord from dicom-microscopy-viewer? Check arguments?
+    static getTID300RepresentationArguments(scoord) {
+        if (scoord.graphicType !== "POLYLINE") {
+            throw new Error("We expected a POLYLINE graphicType");
+        }
 
-    return { points, lengths };
-  }
+        const points = scoord.graphicData;
+        const lengths = 1; // scoord.distances[0];
+
+        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+
+        return { points, lengths };
+    }
 }
 
 // TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and polylines are both POLYLINES
 // Might make more sense to just use a polyline adapter instead of 'length' and 'polyline'
-Polyline.graphicType = 'POLYLINE';
-Polyline.utilityToolType = 'Length';
+Polyline.graphicType = "POLYLINE";
+Polyline.toolType = "Polyline";
+Polyline.utilityToolType = "Polyline";
 Polyline.TID300Representation = TID300Polyline;
 
 MeasurementReport.registerTool(Polyline);


### PR DESCRIPTION
### What
replacing scoord to scoord3d and adding toolType in Polyline

### Why
Since all coords are now in scoord3d format, the ROI should be able to get scoord3d elements