### PR TITLE
Divided datasetToBlob() into dict, buffer, & blob

### DIFF
--- a/src/datasetToBlob.js
+++ b/src/datasetToBlob.js
@@ -1,7 +1,7 @@
 import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
 import { DicomDict } from "./DicomDict.js";
 
-function datasetToBlob(dataset) {
+function datasetToDict(dataset) {
     const meta = {
         FileMetaInformationVersion:
             dataset._meta.FileMetaInformationVersion.Value,
@@ -20,11 +20,17 @@ function datasetToBlob(dataset) {
 
     const denaturalized = DicomMetaDictionary.denaturalizeDataset(meta);
     const dicomDict = new DicomDict(denaturalized);
-
     dicomDict.dict = DicomMetaDictionary.denaturalizeDataset(dataset);
+    return dicomDict;
+}
 
-    const buffer = dicomDict.write();
+function datasetToBuffer(dataset) {
+    return new Buffer(datasetToDict(dataset).write());
+}
+
+function datasetToBlob(dataset) {
+    const buffer = datasetToBuffer(dataset);
     return new Blob([buffer], { type: "application/dicom" });
 }
 
-export { datasetToBlob };
+export { datasetToBlob, datasetToBuffer, datasetToDict };

--- a/src/datasetToBlob.js
+++ b/src/datasetToBlob.js
@@ -25,7 +25,7 @@ function datasetToDict(dataset) {
 }
 
 function datasetToBuffer(dataset) {
-    return datasetToDict(dataset).write();
+    return Buffer.from(datasetToDict(dataset).write());
 }
 
 function datasetToBlob(dataset) {

--- a/src/datasetToBlob.js
+++ b/src/datasetToBlob.js
@@ -25,7 +25,7 @@ function datasetToDict(dataset) {
 }
 
 function datasetToBuffer(dataset) {
-    return new Buffer(datasetToDict(dataset).write());
+    return datasetToDict(dataset).write();
 }
 
 function datasetToBlob(dataset) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,12 @@ import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
 import { DICOMWEB } from "./dicomweb.js";
 import { Tag } from "./Tag.js";
 import { ValueRepresentation } from "./ValueRepresentation.js";
-//export { anonymizer } from './anonymizer.js';
 import { Colors } from "./colors.js";
-import { datasetToBlob } from "./datasetToBlob.js";
+import {
+    datasetToDict,
+    datasetToBuffer,
+    datasetToBlob
+} from "./datasetToBlob.js";
 
 let data = {
     BitArray,
@@ -21,6 +24,8 @@ let data = {
     Tag,
     ValueRepresentation,
     Colors,
+    datasetToDict,
+    datasetToBuffer,
     datasetToBlob
 };
 


### PR DESCRIPTION
node.js doesn't support the Blob type natively. The simple solution (suggested by @JamesAPetts) was to refactor **datasetToBlob()** into smaller chunks, **datasetToDict()** and **datasetToBuffer()**. This lets me read and write DICOM pretty easily:

`
const dicomData = DicomMessage.readFile(fs.readFileSync(source).buffer, {ignoreErrors: false});
const dataset = DicomMetaDictionary.naturalizeDataset(dicomData.dict);
dataset._meta = DicomMetaDictionary.namifyDataset(dicomData.meta);
fs.appendFileSync(destination, datasetToBuffer(dataset));
`

I've confirmed that **datasetToBlob()** functions the same as it did previously, at least in the context of an Electron application.