### PR TITLE
Multi segmentation round2

### DIFF
--- a/examples/createSegmentation/index.html
+++ b/examples/createSegmentation/index.html
@@ -22,7 +22,7 @@
 
       <div class="row">
         <button id="sampleData" onclick="createSeg()">Create Seg</button>
-        <select id="switchBrush" onchange="changeBrush()">
+        <label for="switchBrush">Active Brush: </label><select id="switchBrush" onchange="changeBrush()">
           <option value="0">1</option>
           <option value="1">2</option>
           <option value="2">3</option>
@@ -104,8 +104,6 @@
         var value = document.getElementById("switchBrush").value;
 
         cornerstoneTools.store.modules.brush.state.drawColorId = value;
-
-        console.log(value);
       }
 
       function createSeg() {

--- a/examples/createSegmentationMultiframe/index.html
+++ b/examples/createSegmentationMultiframe/index.html
@@ -15,13 +15,19 @@
       <div class="page-header">
         <h1>Create DICOM Segmentation IOD</h1>
         <p>
-          This example demonstrates how to create a DICOM Segmentation object.
+          This example demonstrates creation of a DICOM Segmentation object on multiframe source data.
         </p>
         <a href="../index.html">Go back to the Examples page</a>
       </div>
 
       <div class="row">
         <button id="sampleData" onclick="createSeg()">Create Seg</button>
+        <select id="switchBrush" onchange="changeBrush()">
+          <option value="0">1</option>
+          <option value="1">2</option>
+          <option value="2">3</option>
+          <option value="3">4</option>
+        <select>
         <p id="statusLine"></p>
         <div class="col-xs-9">
           <div
@@ -92,10 +98,21 @@
     <script>
       let metaData = {};
 
+      document.getElementById("switchBrush")[0].selected = true;
+
+      function changeBrush() {
+        var value = document.getElementById("switchBrush").value;
+
+        cornerstoneTools.store.modules.brush.state.drawColorId = value;
+
+        console.log(value);
+      }
+
       function createSeg() {
         const element = document.getElementsByClassName("viewport-element")[0];
         const globalToolStateManager =
           cornerstoneTools.globalImageIdSpecificToolStateManager;
+        const toolState = globalToolStateManager.saveToolState();
 
         const stackToolState = cornerstoneTools.getToolState(element, "stack");
         const imageIds = stackToolState.data[0].imageIds;
@@ -111,27 +128,46 @@
           0
         ]);
 
-        const brushData = {
-          toolState: globalToolStateManager.saveToolState(),
-          segments: [
-            {
-              SegmentedPropertyCategoryCodeSequence: {
-                CodeValue: "T-D0050",
-                CodingSchemeDesignator: "SRT",
-                CodeMeaning: "Tissue"
-              },
-              SegmentNumber: 1,
-              SegmentLabel: "Tissue",
-              SegmentAlgorithmType: "SEMIAUTOMATIC",
-              SegmentAlgorithmName: "Slicer Prototype",
-              RecommendedDisplayCIELabValue,
-              SegmentedPropertyTypeCodeSequence: {
-                CodeValue: "T-D0050",
-                CodingSchemeDesignator: "SRT",
-                CodeMeaning: "Tissue"
+        const segments = [];
+
+        // Check which segments have been drawn.
+        for (let i = 0; i < imageIds.length; i++) {
+          if (!toolState[imageIds[i]]
+            || !toolState[imageIds[i]].brush
+            || !toolState[imageIds[i]].brush.data) {
+            continue;
+          }
+
+          const brushData = toolState[imageIds[i]].brush.data;
+
+          for (let segIdx = 0; segIdx < 4; segIdx++) {
+            // If there is pixelData for this segment, set the segment metadata
+            // if it hasn't been set yet.
+            if (brushData[segIdx] && brushData[segIdx].pixelData && !segments[segIdx]) {
+              segments[segIdx] = {
+                SegmentedPropertyCategoryCodeSequence: {
+                  CodeValue: "T-D0050",
+                  CodingSchemeDesignator: "SRT",
+                  CodeMeaning: "Tissue"
+                },
+                SegmentNumber: (segIdx + 1).toString(),
+                SegmentLabel: "Tissue " + (segIdx + 1).toString(),
+                SegmentAlgorithmType: "SEMIAUTOMATIC",
+                SegmentAlgorithmName: "Slicer Prototype",
+                RecommendedDisplayCIELabValue,
+                SegmentedPropertyTypeCodeSequence: {
+                  CodeValue: "T-D0050",
+                  CodingSchemeDesignator: "SRT",
+                  CodeMeaning: "Tissue"
+                }
               }
             }
-          ]
+          }
+        }
+
+        const brushData = {
+          toolState,
+          segments
         };
 
         Promise.all(imagePromises)

--- a/examples/displaySegmentation/index.html
+++ b/examples/displaySegmentation/index.html
@@ -93,7 +93,6 @@
       function getAndLoadSeg() {
         var segURL =
           "https://s3.amazonaws.com/IsomicsPublic/SampleData/QIN-H%2BN-0139/1-105-SEG.dcm";
-          // https://s3.amazonaws.com/IsomicsPublic/SampleData/rsna2017/seg/task2/SEG/tumor_User1_Manual_Trial1.dcm
 
         const xhr = new XMLHttpRequest();
 
@@ -151,28 +150,6 @@
       function addMetaData(type, imageId, data) {
         metaData[imageId] = metaData[imageId] || {};
         metaData[imageId][type] = data;
-      }
-
-      //
-      // creates an array of per-frame imageIds in the form needed for cornerstone processing.
-      //
-      function getImageIds(multiframe, baseImageId) {
-        const imageIds = [];
-        const numFrames = Number(multiframe.NumberOfFrames);
-        for (let i = 0; i < numFrames; i++) {
-          let segNum;
-          if (
-            multiframe.PerFrameFunctionalGroupsSequence[i]
-              .SegmentIdentificationSequence
-          ) {
-            segNum =
-              multiframe.PerFrameFunctionalGroupsSequence[i]
-                .SegmentIdentificationSequence.ReferencedSegmentNumber;
-          }
-          const imageId = baseImageId + "?frame=" + i;
-          imageIds.push(imageId);
-        }
-        return imageIds;
       }
 
     </script>

--- a/examples/displaySegmentation/index.html
+++ b/examples/displaySegmentation/index.html
@@ -175,74 +175,6 @@
         return imageIds;
       }
 
-      //
-      // uses cornerstone caching to access a bytearray of the
-      // part10 dicom, then uses dcmjs to parse this
-      // into javascript object and populates the
-      // metadata for the per-frame imageIDs.
-      //
-      function loadMultiFrameAndPopulateMetadata(baseImageId) {
-        return new Promise(function(resolve, reject) {
-          var multiframe;
-          cornerstone.loadAndCacheImage(baseImageId).then(function(image) {
-            var arrayBuffer = image.data.byteArray.buffer;
-
-            dicomData = dcmjs.data.DicomMessage.readFile(arrayBuffer);
-            let dataset = dcmjs.data.DicomMetaDictionary.naturalizeDataset(
-              dicomData.dict
-            );
-            dataset._meta = dcmjs.data.DicomMetaDictionary.namifyDataset(
-              dicomData.meta
-            );
-
-            multiframe = dcmjs.normalizers.Normalizer.normalizeToDataset([
-              dataset
-            ]);
-
-            var SharedFunctionalGroupsSequence =
-              multiframe.SharedFunctionalGroupsSequence;
-
-            var imageOrientationArray =
-              SharedFunctionalGroupsSequence.PlaneOrientationSequence
-                .ImageOrientationPatient;
-
-            var sopInstanceUid = multiframe.SOPInstanceUID;
-
-            const numFrames = Number(multiframe.NumberOfFrames);
-            for (let i = 0; i < numFrames; i++) {
-              const imageId = baseImageId + "?frame=" + i;
-
-              var functionalGroup =
-                multiframe.PerFrameFunctionalGroupsSequence[i];
-              var imagePositionArray =
-                functionalGroup.PlanePositionSequence.ImagePositionPatient;
-
-              var ReferencedSOPInstanceUID =
-                multiframe.ReferencedSeriesSequence.ReferencedInstanceSequence[
-                  i
-                ].ReferencedSOPInstanceUID;
-
-              addMetaData("imagePlane", imageId, {
-                imagePositionPatient: imagePositionArray,
-                rowCosines: [
-                  imageOrientationArray[0],
-                  imageOrientationArray[1],
-                  imageOrientationArray[2]
-                ],
-                columnCosines: [
-                  imageOrientationArray[3],
-                  imageOrientationArray[4],
-                  imageOrientationArray[5]
-                ]
-              });
-
-              addMetaData("sopInstanceUid", imageId, ReferencedSOPInstanceUID);
-            }
-
-            resolve(multiframe);
-          });
-        });
-      }
     </script>
 
     <script>
@@ -252,7 +184,7 @@
         "https://s3.amazonaws.com/IsomicsPublic/SampleData/QIN-H%2BN-0139/PET-sorted/";
 
       var imageNames = [];
-      
+
       for (var i=1; i<546; i++) {
         imageNames.push('PET_HeadNeck_0-' + i + '.dcm');
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -17,8 +17,9 @@
 
     <ul>
         <li><a href="display/index.html">Display DICOM data</a> - Use dcmjs to display DICOM image and metadata</li>
-        <li><a href="createSegmentation/index.html">Create DICOM Segmentation</a> - Use dcmjs to create a DICOM Segmentation file</li>
-        <li><a href="displaySegmentation/index.html">Display DICOM Segmentation with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Segmentation file</li>
+        <li><a href="createSegmentationMultiframe/index.html">Create DICOM Segmentation on multi-frame source data.</a> - Use dcmjs and Cornerstone to create a DICOM Segmentation file referencing multi-frame source data.</li>
+        <li><a href="createSegmentationSingleframe/index.html">Create DICOM Segmentation on single-frame source data.</a> - Use dcmjs and Cornerstone to create a DICOM Segmentation file referencing single-frame source data.</li>
+        <li><a href="displaySegmentation/index.html">Display DICOM Segmentation with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Segmentation file.</li>
         <li><a href="displayParametricMap/index.html">Display DICOM Parametric Map Overlay with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Parametric Map as Overlay</li>
         <li><a href="displayParametricMap2/index.html">Display DICOM Parametric Map with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Parametric Map</li>
         <li><a href="vtkDisplay/index.html">Display DICOM Segmentation with VTKjs</a> - Use dcmjs and VTKjs to display a DICOM Segmentation file</li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -17,8 +17,7 @@
 
     <ul>
         <li><a href="display/index.html">Display DICOM data</a> - Use dcmjs to display DICOM image and metadata</li>
-        <li><a href="createSegmentationMultiframe/index.html">Create DICOM Segmentation on multi-frame source data.</a> - Use dcmjs and Cornerstone to create a DICOM Segmentation file referencing multi-frame source data.</li>
-        <li><a href="createSegmentationSingleframe/index.html">Create DICOM Segmentation on single-frame source data.</a> - Use dcmjs and Cornerstone to create a DICOM Segmentation file referencing single-frame source data.</li>
+        <li><a href="createSegmentation/index.html">Create DICOM Segmentation with Cornerstone.</a> - Use dcmjs and Cornerstone to create a DICOM Segmentation file.</li>
         <li><a href="displaySegmentation/index.html">Display DICOM Segmentation with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Segmentation file.</li>
         <li><a href="displayParametricMap/index.html">Display DICOM Parametric Map Overlay with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Parametric Map as Overlay</li>
         <li><a href="displayParametricMap2/index.html">Display DICOM Parametric Map with Cornerstone</a> - Use dcmjs and Cornerstone to display a DICOM Parametric Map</li>

--- a/src/derivations/Segmentation.js
+++ b/src/derivations/Segmentation.js
@@ -164,9 +164,8 @@ export default class Segmentation extends DerivedPixels {
         const PerFrameFunctionalGroupsSequence = this.dataset
             .PerFrameFunctionalGroupsSequence;
 
-        const isMultiframe = Normalizer.isMultiframeDataset(
-            this.referencedDataset
-        );
+        const ReferencedSeriesSequence = this.referencedDataset
+            .ReferencedSeriesSequence;
 
         for (let i = 0; i < InStackPositionNumbers.length; i++) {
             const frameNumber = InStackPositionNumbers[i];
@@ -191,39 +190,63 @@ export default class Segmentation extends DerivedPixels {
             let ReferencedSOPInstanceUID;
             let ReferencedFrameNumber;
 
-            if (isMultiframe) {
+            if (ReferencedSeriesSequence) {
+                const referencedInstanceSequenceI =
+                    ReferencedSeriesSequence.ReferencedInstanceSequence[i];
+
+                ReferencedSOPClassUID =
+                    referencedInstanceSequenceI.ReferencedSOPClass;
+                ReferencedSOPInstanceUID =
+                    referencedInstanceSequenceI.ReferencedSOPInstanceUID;
+
+                if (Normalizer.isMultiframeSOPClassUID(ReferencedSOPClassUID)) {
+                    ReferencedFrameNumber = frameNumber;
+                }
+            } else {
                 ReferencedSOPClassUID = this.referencedDataset.SOPClassUID;
                 ReferencedSOPInstanceUID = this.referencedDataset
                     .SOPInstanceUID;
                 ReferencedFrameNumber = frameNumber;
-            } else {
-                const referencedDatasetForFrame = this.referencedDatasets[
-                    frameNumber - 1
-                ];
-                ReferencedSOPClassUID = referencedDatasetForFrame.SOPClassUID;
-                ReferencedSOPInstanceUID =
-                    referencedDatasetForFrame.SOPInstanceUID;
-                ReferencedFrameNumber = 1;
             }
 
-            perFrameFunctionalGroups.DerivationImageSequence = {
-                SourceImageSequence: {
-                    ReferencedSOPClassUID,
-                    ReferencedSOPInstanceUID,
-                    ReferencedFrameNumber,
-                    PurposeOfReferenceCodeSequence: {
-                        CodeValue: "121322",
+            if (ReferencedFrameNumber) {
+                perFrameFunctionalGroups.DerivationImageSequence = {
+                    SourceImageSequence: {
+                        ReferencedSOPClassUID,
+                        ReferencedSOPInstanceUID,
+                        ReferencedFrameNumber,
+                        PurposeOfReferenceCodeSequence: {
+                            CodeValue: "121322",
+                            CodingSchemeDesignator: "DCM",
+                            CodeMeaning:
+                                "Source image for image processing operation"
+                        }
+                    },
+                    DerivationCodeSequence: {
+                        CodeValue: "113076",
                         CodingSchemeDesignator: "DCM",
-                        CodeMeaning:
-                            "Source image for image processing operation"
+                        CodeMeaning: "Segmentation"
                     }
-                },
-                DerivationCodeSequence: {
-                    CodeValue: "113076",
-                    CodingSchemeDesignator: "DCM",
-                    CodeMeaning: "Segmentation"
-                }
-            };
+                };
+            } else {
+                perFrameFunctionalGroups.DerivationImageSequence = {
+                    SourceImageSequence: {
+                        ReferencedSOPClassUID,
+                        ReferencedSOPInstanceUID,
+                        PurposeOfReferenceCodeSequence: {
+                            CodeValue: "121322",
+                            CodingSchemeDesignator: "DCM",
+                            CodeMeaning:
+                                "Source image for image processing operation"
+                        }
+                    },
+                    DerivationCodeSequence: {
+                        CodeValue: "113076",
+                        CodingSchemeDesignator: "DCM",
+                        CodeMeaning: "Segmentation"
+                    }
+                };
+            }
 
             PerFrameFunctionalGroupsSequence.push(perFrameFunctionalGroups);
         }


### PR DESCRIPTION
- Correctly populate `SourceImageSequence` groups of the `PerFrameFunctionalGroups` for segmentations that reference both single framed and multi-framed image data.
- Updated `createSegmentation` example to allow drawing of multiple segments. Improved the Cornerstone adapter to support this.
- Support metadata providers that return `rowCosines`/`columnCosines` in either array or `{x, y, z}` format ala OHIF.