### PR TITLE
Load Segmentation onto correct cornerstone imageIds for multiframe images.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Javascript implementation of DICOM manipulation",
   "main": "build/dcmjs.js",
   "module": "build/dcmjs.es.js",

--- a/src/adapters/Cornerstone/Segmentation.js
+++ b/src/adapters/Cornerstone/Segmentation.js
@@ -503,7 +503,7 @@ function getImageIdOfReferencedFrame(
     imageIds,
     metadataProvider
 ) {
-    return imageIds.find(imageId => {
+    const imageId = imageIds.find(imageId => {
         const sopCommonModule = metadataProvider.get(
             "sopCommonModule",
             imageId
@@ -512,15 +512,16 @@ function getImageIdOfReferencedFrame(
             return;
         }
 
-        // TODO: Need to add something to return frameNumber into Cornerstone WADO Image Loader
-        // metadataProviders
-        const imageFrameNumber = metadataProvider.get("frameNumber", imageId);
+        const imageIdFrameNumber = Number(imageId.split("frame=")[1]);
 
         return (
+            //frameNumber is zero indexed for cornerstoneWADOImageLoader image Ids.
             sopCommonModule.sopInstanceUID === sopInstanceUid &&
-            imageFrameNumber === frameNumber
+            imageIdFrameNumber === frameNumber - 1
         );
     });
+
+    return imageId;
 }
 
 /**


### PR DESCRIPTION
Correctly find `cornerstoneWADOImageLoader` `imageId`s given `SOPInstanceUID` and `FrameNumber` for Segmentation cornerstone import.

This really should have been in my last PR. Even though my last PR only patched incomplete functionality, I'm now developing on a local NPM lib and will PR only more complete patches.