### PR TITLE
Generate/Load SR for microscopy viewer tools

### DIFF
--- a/src/adapters/DICOMMicroscopyViewer/Circle.js
+++ b/src/adapters/DICOMMicroscopyViewer/Circle.js
@@ -1,0 +1,36 @@
+import MeasurementReport from "./MeasurementReport.js";
+import TID300Circle from "../../utilities/TID300/Circle";
+
+class Circle {
+    constructor() {}
+
+    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
+    static getMeasurementData(measurementContent) {
+        return measurementContent.ContentSequence.GraphicData;
+    }
+
+    // Expects a Circle scoord from dicom-microscopy-viewer? Check arguments?
+    static getTID300RepresentationArguments(scoord) {
+        if (scoord.graphicType !== "CIRCLE") {
+            throw new Error("We expected a CIRCLE graphicType");
+        }
+
+        const points = scoord.graphicData;
+        const lengths = 1; // scoord.distances[0];
+
+        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+
+        return { points, lengths };
+    }
+}
+
+// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and circles are both CIRCLES
+// Might make more sense to just use a circle adapter instead of 'length' and 'circle'
+Circle.graphicType = "CIRCLE";
+Circle.toolType = "Circle";
+Circle.utilityToolType = "Circle";
+Circle.TID300Representation = TID300Circle;
+
+MeasurementReport.registerTool(Circle);
+
+export default Circle;

--- a/src/adapters/DICOMMicroscopyViewer/Circle.js
+++ b/src/adapters/DICOMMicroscopyViewer/Circle.js
@@ -4,28 +4,22 @@ import TID300Circle from "../../utilities/TID300/Circle";
 class Circle {
     constructor() {}
 
-    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(measurementContent) {
         return measurementContent.ContentSequence.GraphicData;
     }
 
-    // Expects a Circle scoord from dicom-microscopy-viewer? Check arguments?
-    static getTID300RepresentationArguments(scoord) {
-        if (scoord.graphicType !== "CIRCLE") {
+    static getTID300RepresentationArguments(scoord3d) {
+        if (scoord3d.graphicType !== "CIRCLE") {
             throw new Error("We expected a CIRCLE graphicType");
         }
 
-        const points = scoord.graphicData;
-        const lengths = 1; // scoord.distances[0];
-
-        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+        const points = scoord3d.graphicData;
+        const lengths = 1;
 
         return { points, lengths };
     }
 }
 
-// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and circles are both CIRCLES
-// Might make more sense to just use a circle adapter instead of 'length' and 'circle'
 Circle.graphicType = "CIRCLE";
 Circle.toolType = "Circle";
 Circle.utilityToolType = "Circle";

--- a/src/adapters/DICOMMicroscopyViewer/Circle.js
+++ b/src/adapters/DICOMMicroscopyViewer/Circle.js
@@ -5,7 +5,23 @@ class Circle {
     constructor() {}
 
     static getMeasurementData(measurementContent) {
-        return measurementContent.ContentSequence.GraphicData;
+        // removing duplication and Getting only the graphicData information
+        const measurement = measurementContent
+            .map(item => item.ContentSequence.GraphicData)
+            .filter(
+                (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
+                    new Set()
+                )
+            );
+
+        // Chunking the array into size of three
+        return measurement.map(measurement => {
+            return measurement.reduce((all, one, i) => {
+                const ch = Math.floor(i / 3);
+                all[ch] = [].concat(all[ch] || [], one);
+                return all;
+            }, []);
+        });
     }
 
     static getTID300RepresentationArguments(scoord3d) {

--- a/src/adapters/DICOMMicroscopyViewer/MeasurementReport.js
+++ b/src/adapters/DICOMMicroscopyViewer/MeasurementReport.js
@@ -161,10 +161,10 @@ export default class MeasurementReport {
             const measurementGroups = toArray(
                 measurementGroupContent.ContentSequence
             );
-            const measurementContent = measurementGroups.find(
+            let measurementContent = measurementGroups.filter(
                 graphicTypeEquals(measurementType.toUpperCase())
             );
-            if (!measurementContent) {
+            if (!measurementContent || measurementContent.length === 0) {
                 return;
             }
 
@@ -180,10 +180,18 @@ export default class MeasurementReport {
                 );
             }
 
-            // Retrieve Length Measurement Data
+            // measurementContent = measurementContent.map(item => item.ContentSequence.GraphicData)
+            //     .filter((graphicData, index, self) => self.indexOf(graphicData) === index)
+
+            // measurementData[toolType] = new Array()
             measurementData[toolType] = toolClass.getMeasurementData(
                 measurementContent
             );
+
+            // measurementContent.forEach(measurement =>{
+            // })
+
+            // Retrieve Length Measurement Data
         });
 
         return measurementData;

--- a/src/adapters/DICOMMicroscopyViewer/MeasurementReport.js
+++ b/src/adapters/DICOMMicroscopyViewer/MeasurementReport.js
@@ -34,8 +34,11 @@ export default class MeasurementReport {
         const measurementsByGraphicType = {};
         rois.forEach(roi => {
             const graphicType = roi.scoord3d.graphicType;
-            // adding z coord as 0
-            roi.scoord3d.coordinates.map(coord => coord.push(0));
+
+            if (graphicType !== "POINT") {
+                // adding z coord as 0
+                roi.scoord3d.graphicData.map(coord => coord.push(0));
+            }
 
             if (!measurementsByGraphicType[graphicType]) {
                 measurementsByGraphicType[graphicType] = [];

--- a/src/adapters/DICOMMicroscopyViewer/Point.js
+++ b/src/adapters/DICOMMicroscopyViewer/Point.js
@@ -5,7 +5,14 @@ class Point {
     constructor() {}
 
     static getMeasurementData(measurementContent) {
-        return measurementContent.ContentSequence.GraphicData;
+        const measurement = measurementContent.map(
+            item => item.ContentSequence.GraphicData
+        );
+        return measurement.filter(
+            (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
+                new Set()
+            )
+        );
     }
 
     static getTID300RepresentationArguments(scoord3d) {

--- a/src/adapters/DICOMMicroscopyViewer/Point.js
+++ b/src/adapters/DICOMMicroscopyViewer/Point.js
@@ -1,0 +1,36 @@
+import MeasurementReport from "./MeasurementReport.js";
+import TID300Point from "../../utilities/TID300/Point";
+
+class Point {
+    constructor() {}
+
+    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
+    static getMeasurementData(measurementContent) {
+        return measurementContent.ContentSequence.GraphicData;
+    }
+
+    // Expects a Point scoord from dicom-microscopy-viewer? Check arguments?
+    static getTID300RepresentationArguments(scoord) {
+        if (scoord.graphicType !== "POINT") {
+            throw new Error("We expected a POINT graphicType");
+        }
+
+        const points = [scoord.graphicData];
+        const lengths = 1; // scoord.distances[0];
+
+        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+
+        return { points, lengths };
+    }
+}
+
+// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and points are both POLYLINES
+// Might make more sense to just use a point adapter instead of 'length' and 'point'
+Point.graphicType = "POINT";
+Point.toolType = "Point";
+Point.utilityToolType = "Point";
+Point.TID300Representation = TID300Point;
+
+MeasurementReport.registerTool(Point);
+
+export default Point;

--- a/src/adapters/DICOMMicroscopyViewer/Point.js
+++ b/src/adapters/DICOMMicroscopyViewer/Point.js
@@ -4,28 +4,22 @@ import TID300Point from "../../utilities/TID300/Point";
 class Point {
     constructor() {}
 
-    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(measurementContent) {
         return measurementContent.ContentSequence.GraphicData;
     }
 
-    // Expects a Point scoord from dicom-microscopy-viewer? Check arguments?
-    static getTID300RepresentationArguments(scoord) {
-        if (scoord.graphicType !== "POINT") {
+    static getTID300RepresentationArguments(scoord3d) {
+        if (scoord3d.graphicType !== "POINT") {
             throw new Error("We expected a POINT graphicType");
         }
 
-        const points = [scoord.graphicData];
-        const lengths = 1; // scoord.distances[0];
-
-        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+        const points = [scoord3d.graphicData];
+        const lengths = 1;
 
         return { points, lengths };
     }
 }
 
-// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and points are both POLYLINES
-// Might make more sense to just use a point adapter instead of 'length' and 'point'
 Point.graphicType = "POINT";
 Point.toolType = "Point";
 Point.utilityToolType = "Point";

--- a/src/adapters/DICOMMicroscopyViewer/Polygon.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polygon.js
@@ -5,7 +5,23 @@ class Polygon {
     constructor() {}
 
     static getMeasurementData(measurementContent) {
-        return measurementContent.ContentSequence.GraphicData;
+        // removing duplication and Getting only the graphicData information
+        const measurement = measurementContent
+            .map(item => item.ContentSequence.GraphicData)
+            .filter(
+                (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
+                    new Set()
+                )
+            );
+
+        // Chunking the array into size of three
+        return measurement.map(measurement => {
+            return measurement.reduce((all, one, i) => {
+                const ch = Math.floor(i / 3);
+                all[ch] = [].concat(all[ch] || [], one);
+                return all;
+            }, []);
+        });
     }
 
     static getTID300RepresentationArguments(scoord3d) {

--- a/src/adapters/DICOMMicroscopyViewer/Polygon.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polygon.js
@@ -1,0 +1,36 @@
+import MeasurementReport from "./MeasurementReport.js";
+import TID300Polygon from "../../utilities/TID300/Polygon";
+
+class Polygon {
+    constructor() {}
+
+    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
+    static getMeasurementData(measurementContent) {
+        return measurementContent.ContentSequence.GraphicData;
+    }
+
+    // Expects a Polygon scoord from dicom-microscopy-viewer? Check arguments?
+    static getTID300RepresentationArguments(scoord) {
+        if (scoord.graphicType !== "POLYGON") {
+            throw new Error("We expected a POLYGON graphicType");
+        }
+
+        const points = scoord.graphicData;
+        const lengths = 1; // scoord.distances[0];
+
+        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+
+        return { points, lengths };
+    }
+}
+
+// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and polygons are both POLYLINES
+// Might make more sense to just use a polygon adapter instead of 'length' and 'polygon'
+Polygon.graphicType = "POLYGON";
+Polygon.toolType = "Polygon";
+Polygon.utilityToolType = "Polygon";
+Polygon.TID300Representation = TID300Polygon;
+
+MeasurementReport.registerTool(Polygon);
+
+export default Polygon;

--- a/src/adapters/DICOMMicroscopyViewer/Polygon.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polygon.js
@@ -4,28 +4,22 @@ import TID300Polygon from "../../utilities/TID300/Polygon";
 class Polygon {
     constructor() {}
 
-    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(measurementContent) {
         return measurementContent.ContentSequence.GraphicData;
     }
 
-    // Expects a Polygon scoord from dicom-microscopy-viewer? Check arguments?
-    static getTID300RepresentationArguments(scoord) {
-        if (scoord.graphicType !== "POLYGON") {
+    static getTID300RepresentationArguments(scoord3d) {
+        if (scoord3d.graphicType !== "POLYGON") {
             throw new Error("We expected a POLYGON graphicType");
         }
 
-        const points = scoord.graphicData;
-        const lengths = 1; // scoord.distances[0];
-
-        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+        const points = scoord3d.graphicData;
+        const lengths = 1;
 
         return { points, lengths };
     }
 }
 
-// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and polygons are both POLYLINES
-// Might make more sense to just use a polygon adapter instead of 'length' and 'polygon'
 Polygon.graphicType = "POLYGON";
 Polygon.toolType = "Polygon";
 Polygon.utilityToolType = "Polygon";

--- a/src/adapters/DICOMMicroscopyViewer/Polyline.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polyline.js
@@ -4,28 +4,22 @@ import TID300Polyline from "../../utilities/TID300/Polyline";
 class Polyline {
     constructor() {}
 
-    // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(measurementContent) {
         return measurementContent.ContentSequence.GraphicData;
     }
 
-    // Expects a Polyline scoord from dicom-microscopy-viewer? Check arguments?
-    static getTID300RepresentationArguments(scoord) {
-        if (scoord.graphicType !== "POLYLINE") {
+    static getTID300RepresentationArguments(scoord3d) {
+        if (scoord3d.graphicType !== "POLYLINE") {
             throw new Error("We expected a POLYLINE graphicType");
         }
 
-        const points = scoord.graphicData;
-        const lengths = 1; // scoord.distances[0];
-
-        // FROM dicom-microscopy-viewer format TO dcmjs adapter format
+        const points = scoord3d.graphicData;
+        const lengths = 1;
 
         return { points, lengths };
     }
 }
 
-// TODO: Using dicom-microscopy-viewer's graphic type may not work since both lines and polylines are both POLYLINES
-// Might make more sense to just use a polyline adapter instead of 'length' and 'polyline'
 Polyline.graphicType = "POLYLINE";
 Polyline.toolType = "Polyline";
 Polyline.utilityToolType = "Polyline";

--- a/src/adapters/DICOMMicroscopyViewer/Polyline.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polyline.js
@@ -5,7 +5,23 @@ class Polyline {
     constructor() {}
 
     static getMeasurementData(measurementContent) {
-        return measurementContent.ContentSequence.GraphicData;
+        // removing duplication and Getting only the graphicData information
+        const measurement = measurementContent
+            .map(item => item.ContentSequence.GraphicData)
+            .filter(
+                (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
+                    new Set()
+                )
+            );
+
+        // Chunking the array into size of three
+        return measurement.map(measurement => {
+            return measurement.reduce((all, one, i) => {
+                const ch = Math.floor(i / 3);
+                all[ch] = [].concat(all[ch] || [], one);
+                return all;
+            }, []);
+        });
     }
 
     static getTID300RepresentationArguments(scoord3d) {

--- a/src/adapters/DICOMMicroscopyViewer/index.js
+++ b/src/adapters/DICOMMicroscopyViewer/index.js
@@ -2,11 +2,13 @@ import MeasurementReport from "./MeasurementReport.js";
 import Polyline from "./Polyline.js";
 import Polygon from "./Polygon.js";
 import Point from "./Point.js";
+import Circle from "./Circle.js";
 
 const DICOMMicroscopyViewer = {
     Polyline,
     Polygon,
     Point,
+    Circle,
     MeasurementReport
 };
 

--- a/src/adapters/DICOMMicroscopyViewer/index.js
+++ b/src/adapters/DICOMMicroscopyViewer/index.js
@@ -1,8 +1,12 @@
 import MeasurementReport from "./MeasurementReport.js";
 import Polyline from "./Polyline.js";
+import Polygon from "./Polygon.js";
+import Point from "./Point.js";
 
 const DICOMMicroscopyViewer = {
     Polyline,
+    Polygon,
+    Point,
     MeasurementReport
 };
 

--- a/src/utilities/TID300/Circle.js
+++ b/src/utilities/TID300/Circle.js
@@ -1,0 +1,158 @@
+import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
+import TID300Measurement from "./TID300Measurement.js";
+
+/**
+ * Expand an array of points stored as objects into
+ * a flattened array of points
+ *
+ * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
+ * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
+ */
+function expandPoints(points) {
+    const allPoints = [];
+
+    points.forEach(point => {
+        allPoints.push(point[0]);
+        allPoints.push(point[1]);
+        if (point[2] !== undefined) {
+            allPoints.push(point[2]);
+        }
+    });
+
+    return allPoints;
+}
+
+export default class Circle extends TID300Measurement {
+    // Note: the last point should be equal to the first point to indicate that the polyline is closed.
+    constructor({
+        points,
+        lengths,
+        ReferencedSOPSequence,
+        use3DSpatialCoordinates = false
+    }) {
+        super();
+
+        this.points = points;
+        this.lengths = lengths; // Array of lengths between each point
+        this.ReferencedSOPSequence = ReferencedSOPSequence;
+        this.use3DSpatialCoordinates = use3DSpatialCoordinates;
+    }
+
+    contentItem() {
+        const {
+            points,
+            lengths,
+            ReferencedSOPSequence,
+            use3DSpatialCoordinates = false
+        } = this;
+
+        // Combine all lengths to save the perimeter
+        // @ToDO The permiter has to be implemented
+        // const reducer = (accumulator, currentValue) => accumulator + currentValue;
+        // const perimeter = lengths.reduce(reducer);
+        const perimeter = {};
+        const GraphicData = expandPoints(points);
+
+        // TODO: Add Mean and STDev value of (modality?) pixels
+
+        return [
+            {
+                RelationshipType: "HAS OBS CONTEXT",
+                ValueType: "TEXT",
+                ConceptNameCodeSequence: {
+                    CodeValue: "112039",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Tracking Identifier"
+                },
+                TextValue: "web annotation"
+            },
+            {
+                RelationshipType: "HAS OBS CONTEXT",
+                ValueType: "UIDREF",
+                ConceptNameCodeSequence: {
+                    CodeValue: "112040",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Tracking Unique Identifier"
+                },
+                UID: DicomMetaDictionary.uid()
+            },
+            {
+                RelationshipType: "CONTAINS",
+                ValueType: "CODE",
+                ConceptNameCodeSequence: {
+                    CodeValue: "121071",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Finding"
+                },
+                ConceptCodeSequence: {
+                    CodeValue: "SAMPLEFINDING",
+                    CodingSchemeDesignator: "99dcmjs",
+                    CodeMeaning: "Sample Finding"
+                }
+            },
+            {
+                RelationshipType: "CONTAINS",
+                ValueType: "NUM",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-A197",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Perimeter" // TODO: Look this up from a Code Meaning dictionary
+                },
+                MeasuredValueSequence: {
+                    MeasurementUnitsCodeSequence: {
+                        CodeValue: "mm",
+                        CodingSchemeDesignator: "UCUM",
+                        CodingSchemeVersion: "1.4",
+                        CodeMeaning: "millimeter"
+                    },
+                    NumericValue: perimeter
+                },
+                ContentSequence: {
+                    RelationshipType: "INFERRED FROM",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
+                    GraphicType: "CIRCLE",
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
+                }
+            },
+            {
+                // TODO: This feels weird to repeat the GraphicData
+                RelationshipType: "CONTAINS",
+                ValueType: "NUM",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-A166",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Area" // TODO: Look this up from a Code Meaning dictionary
+                },
+                MeasuredValueSequence: {
+                    MeasurementUnitsCodeSequence: {
+                        CodeValue: "mm2",
+                        CodingSchemeDesignator: "UCUM",
+                        CodingSchemeVersion: "1.4",
+                        CodeMeaning: "SquareMilliMeter"
+                    },
+                    NumericValue: perimeter
+                },
+                ContentSequence: {
+                    RelationshipType: "INFERRED FROM",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
+                    GraphicType: "CIRCLE",
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
+                }
+            }
+        ];
+    }
+}

--- a/src/utilities/TID300/Circle.js
+++ b/src/utilities/TID300/Circle.js
@@ -14,16 +14,13 @@ function expandPoints(points) {
     points.forEach(point => {
         allPoints.push(point[0]);
         allPoints.push(point[1]);
-        if (point[2] !== undefined) {
-            allPoints.push(point[2]);
-        }
+        allPoints.push(point[2]);
     });
 
     return allPoints;
 }
 
 export default class Circle extends TID300Measurement {
-    // Note: the last point should be equal to the first point to indicate that the polyline is closed.
     constructor({
         points,
         lengths,
@@ -33,7 +30,7 @@ export default class Circle extends TID300Measurement {
         super();
 
         this.points = points;
-        this.lengths = lengths; // Array of lengths between each point
+        this.lengths = lengths;
         this.ReferencedSOPSequence = ReferencedSOPSequence;
         this.use3DSpatialCoordinates = use3DSpatialCoordinates;
     }

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -12,7 +12,7 @@ export default class Point extends TID300Measurement {
         super();
 
         this.points = points;
-        this.lengths = lengths; // Array of lengths between each point
+        this.lengths = lengths;
         this.ReferencedSOPSequence = ReferencedSOPSequence;
         this.use3DSpatialCoordinates = use3DSpatialCoordinates;
     }
@@ -25,14 +25,8 @@ export default class Point extends TID300Measurement {
             use3DSpatialCoordinates = false
         } = this;
 
-        // Combine all lengths to save the perimeter
-        // @ToDO The permiter has to be implemented
-        // const reducer = (accumulator, currentValue) => accumulator + currentValue;
-        // const perimeter = lengths.reduce(reducer);
         const perimeter = {};
         const GraphicData = points[0];
-
-        // TODO: Add Mean and STDev value of (modality?) pixels
 
         return [
             {

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -1,27 +1,6 @@
 import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
 import TID300Measurement from "./TID300Measurement.js";
 
-/**
- * Expand an array of points stored as objects into
- * a flattened array of points
- *
- * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
- * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
- */
-function expandPoints(points) {
-    const allPoints = [];
-
-    points.forEach(point => {
-        allPoints.push(point[0]);
-        allPoints.push(point[1]);
-        if (point[2] !== undefined) {
-            allPoints.push(point[2]);
-        }
-    });
-
-    return allPoints;
-}
-
 export default class Point extends TID300Measurement {
     // Note: the last point should be equal to the first point to indicate that the point is closed.
     constructor({
@@ -51,7 +30,7 @@ export default class Point extends TID300Measurement {
         // const reducer = (accumulator, currentValue) => accumulator + currentValue;
         // const perimeter = lengths.reduce(reducer);
         const perimeter = {};
-        const GraphicData = expandPoints(points);
+        const GraphicData = points[0];
 
         // TODO: Add Mean and STDev value of (modality?) pixels
 

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -100,7 +100,7 @@ export default class Point extends TID300Measurement {
                 ConceptNameCodeSequence: {
                     CodeValue: "G-A166",
                     CodingSchemeDesignator: "SRT",
-                    CodeMeaning: "Area" // TODO: Look this up from a Code Meaning dictionary
+                    CodeMeaning: "Area"
                 },
                 MeasuredValueSequence: {
                     MeasurementUnitsCodeSequence: {

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -2,7 +2,6 @@ import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
 import TID300Measurement from "./TID300Measurement.js";
 
 export default class Point extends TID300Measurement {
-    // Note: the last point should be equal to the first point to indicate that the point is closed.
     constructor({
         points,
         lengths,

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -1,0 +1,158 @@
+import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
+import TID300Measurement from "./TID300Measurement.js";
+
+/**
+ * Expand an array of points stored as objects into
+ * a flattened array of points
+ *
+ * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
+ * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
+ */
+function expandPoints(points) {
+    const allPoints = [];
+
+    points.forEach(point => {
+        allPoints.push(point[0]);
+        allPoints.push(point[1]);
+        if (point[2] !== undefined) {
+            allPoints.push(point[2]);
+        }
+    });
+
+    return allPoints;
+}
+
+export default class Point extends TID300Measurement {
+    // Note: the last point should be equal to the first point to indicate that the point is closed.
+    constructor({
+        points,
+        lengths,
+        ReferencedSOPSequence,
+        use3DSpatialCoordinates = false
+    }) {
+        super();
+
+        this.points = points;
+        this.lengths = lengths; // Array of lengths between each point
+        this.ReferencedSOPSequence = ReferencedSOPSequence;
+        this.use3DSpatialCoordinates = use3DSpatialCoordinates;
+    }
+
+    contentItem() {
+        const {
+            points,
+            lengths,
+            ReferencedSOPSequence,
+            use3DSpatialCoordinates = false
+        } = this;
+
+        // Combine all lengths to save the perimeter
+        // @ToDO The permiter has to be implemented
+        // const reducer = (accumulator, currentValue) => accumulator + currentValue;
+        // const perimeter = lengths.reduce(reducer);
+        const perimeter = {};
+        const GraphicData = expandPoints(points);
+
+        // TODO: Add Mean and STDev value of (modality?) pixels
+
+        return [
+            {
+                RelationshipType: "HAS OBS CONTEXT",
+                ValueType: "TEXT",
+                ConceptNameCodeSequence: {
+                    CodeValue: "112039",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Tracking Identifier"
+                },
+                TextValue: "web annotation"
+            },
+            {
+                RelationshipType: "HAS OBS CONTEXT",
+                ValueType: "UIDREF",
+                ConceptNameCodeSequence: {
+                    CodeValue: "112040",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Tracking Unique Identifier"
+                },
+                UID: DicomMetaDictionary.uid()
+            },
+            {
+                RelationshipType: "CONTAINS",
+                ValueType: "CODE",
+                ConceptNameCodeSequence: {
+                    CodeValue: "121071",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Finding"
+                },
+                ConceptCodeSequence: {
+                    CodeValue: "SAMPLEFINDING",
+                    CodingSchemeDesignator: "99dcmjs",
+                    CodeMeaning: "Sample Finding"
+                }
+            },
+            {
+                RelationshipType: "CONTAINS",
+                ValueType: "NUM",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-A197",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Perimeter" // TODO: Look this up from a Code Meaning dictionary
+                },
+                MeasuredValueSequence: {
+                    MeasurementUnitsCodeSequence: {
+                        CodeValue: "mm",
+                        CodingSchemeDesignator: "UCUM",
+                        CodingSchemeVersion: "1.4",
+                        CodeMeaning: "millimeter"
+                    },
+                    NumericValue: perimeter
+                },
+                ContentSequence: {
+                    RelationshipType: "INFERRED FROM",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
+                    GraphicType: "POINT",
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
+                }
+            },
+            {
+                // TODO: This feels weird to repeat the GraphicData
+                RelationshipType: "CONTAINS",
+                ValueType: "NUM",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-A166",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Area" // TODO: Look this up from a Code Meaning dictionary
+                },
+                MeasuredValueSequence: {
+                    MeasurementUnitsCodeSequence: {
+                        CodeValue: "mm2",
+                        CodingSchemeDesignator: "UCUM",
+                        CodingSchemeVersion: "1.4",
+                        CodeMeaning: "SquareMilliMeter"
+                    },
+                    NumericValue: perimeter
+                },
+                ContentSequence: {
+                    RelationshipType: "INFERRED FROM",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
+                    GraphicType: "POINT",
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
+                }
+            }
+        ];
+    }
+}

--- a/src/utilities/TID300/Polygon.js
+++ b/src/utilities/TID300/Polygon.js
@@ -23,7 +23,6 @@ function expandPoints(points) {
 }
 
 export default class Polygon extends TID300Measurement {
-    // Note: the last point should be equal to the first point to indicate that the polygon is closed.
     constructor({
         points,
         lengths,
@@ -33,7 +32,7 @@ export default class Polygon extends TID300Measurement {
         super();
 
         this.points = points;
-        this.lengths = lengths; // Array of lengths between each point
+        this.lengths = lengths;
         this.ReferencedSOPSequence = ReferencedSOPSequence;
         this.use3DSpatialCoordinates = use3DSpatialCoordinates;
     }
@@ -46,14 +45,8 @@ export default class Polygon extends TID300Measurement {
             use3DSpatialCoordinates = false
         } = this;
 
-        // Combine all lengths to save the perimeter
-        // @ToDO The permiter has to be implemented
-        // const reducer = (accumulator, currentValue) => accumulator + currentValue;
-        // const perimeter = lengths.reduce(reducer);
         const perimeter = {};
         const GraphicData = expandPoints(points);
-
-        // TODO: Add Mean and STDev value of (modality?) pixels
 
         return [
             {
@@ -96,7 +89,7 @@ export default class Polygon extends TID300Measurement {
                 ConceptNameCodeSequence: {
                     CodeValue: "G-A197",
                     CodingSchemeDesignator: "SRT",
-                    CodeMeaning: "Perimeter" // TODO: Look this up from a Code Meaning dictionary
+                    CodeMeaning: "Perimeter"
                 },
                 MeasuredValueSequence: {
                     MeasurementUnitsCodeSequence: {
@@ -122,13 +115,12 @@ export default class Polygon extends TID300Measurement {
                 }
             },
             {
-                // TODO: This feels weird to repeat the GraphicData
                 RelationshipType: "CONTAINS",
                 ValueType: "NUM",
                 ConceptNameCodeSequence: {
                     CodeValue: "G-A166",
                     CodingSchemeDesignator: "SRT",
-                    CodeMeaning: "Area" // TODO: Look this up from a Code Meaning dictionary
+                    CodeMeaning: "Area"
                 },
                 MeasuredValueSequence: {
                     MeasurementUnitsCodeSequence: {

--- a/src/utilities/TID300/Polygon.js
+++ b/src/utilities/TID300/Polygon.js
@@ -1,0 +1,158 @@
+import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
+import TID300Measurement from "./TID300Measurement.js";
+
+/**
+ * Expand an array of points stored as objects into
+ * a flattened array of points
+ *
+ * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
+ * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
+ */
+function expandPoints(points) {
+    const allPoints = [];
+
+    points.forEach(point => {
+        allPoints.push(point[0]);
+        allPoints.push(point[1]);
+        if (point[2] !== undefined) {
+            allPoints.push(point[2]);
+        }
+    });
+
+    return allPoints;
+}
+
+export default class Polygon extends TID300Measurement {
+    // Note: the last point should be equal to the first point to indicate that the polygon is closed.
+    constructor({
+        points,
+        lengths,
+        ReferencedSOPSequence,
+        use3DSpatialCoordinates = false
+    }) {
+        super();
+
+        this.points = points;
+        this.lengths = lengths; // Array of lengths between each point
+        this.ReferencedSOPSequence = ReferencedSOPSequence;
+        this.use3DSpatialCoordinates = use3DSpatialCoordinates;
+    }
+
+    contentItem() {
+        const {
+            points,
+            lengths,
+            ReferencedSOPSequence,
+            use3DSpatialCoordinates = false
+        } = this;
+
+        // Combine all lengths to save the perimeter
+        // @ToDO The permiter has to be implemented
+        // const reducer = (accumulator, currentValue) => accumulator + currentValue;
+        // const perimeter = lengths.reduce(reducer);
+        const perimeter = {};
+        const GraphicData = expandPoints(points);
+
+        // TODO: Add Mean and STDev value of (modality?) pixels
+
+        return [
+            {
+                RelationshipType: "HAS OBS CONTEXT",
+                ValueType: "TEXT",
+                ConceptNameCodeSequence: {
+                    CodeValue: "112039",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Tracking Identifier"
+                },
+                TextValue: "web annotation"
+            },
+            {
+                RelationshipType: "HAS OBS CONTEXT",
+                ValueType: "UIDREF",
+                ConceptNameCodeSequence: {
+                    CodeValue: "112040",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Tracking Unique Identifier"
+                },
+                UID: DicomMetaDictionary.uid()
+            },
+            {
+                RelationshipType: "CONTAINS",
+                ValueType: "CODE",
+                ConceptNameCodeSequence: {
+                    CodeValue: "121071",
+                    CodingSchemeDesignator: "DCM",
+                    CodeMeaning: "Finding"
+                },
+                ConceptCodeSequence: {
+                    CodeValue: "SAMPLEFINDING",
+                    CodingSchemeDesignator: "99dcmjs",
+                    CodeMeaning: "Sample Finding"
+                }
+            },
+            {
+                RelationshipType: "CONTAINS",
+                ValueType: "NUM",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-A197",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Perimeter" // TODO: Look this up from a Code Meaning dictionary
+                },
+                MeasuredValueSequence: {
+                    MeasurementUnitsCodeSequence: {
+                        CodeValue: "mm",
+                        CodingSchemeDesignator: "UCUM",
+                        CodingSchemeVersion: "1.4",
+                        CodeMeaning: "millimeter"
+                    },
+                    NumericValue: perimeter
+                },
+                ContentSequence: {
+                    RelationshipType: "INFERRED FROM",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
+                    GraphicType: "POLYGON",
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
+                }
+            },
+            {
+                // TODO: This feels weird to repeat the GraphicData
+                RelationshipType: "CONTAINS",
+                ValueType: "NUM",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-A166",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Area" // TODO: Look this up from a Code Meaning dictionary
+                },
+                MeasuredValueSequence: {
+                    MeasurementUnitsCodeSequence: {
+                        CodeValue: "mm2",
+                        CodingSchemeDesignator: "UCUM",
+                        CodingSchemeVersion: "1.4",
+                        CodeMeaning: "SquareMilliMeter"
+                    },
+                    NumericValue: perimeter
+                },
+                ContentSequence: {
+                    RelationshipType: "INFERRED FROM",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
+                    GraphicType: "POLYGON",
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
+                }
+            }
+        ];
+    }
+}

--- a/src/utilities/TID300/Polyline.js
+++ b/src/utilities/TID300/Polyline.js
@@ -23,7 +23,6 @@ function expandPoints(points) {
 }
 
 export default class Polyline extends TID300Measurement {
-    // Note: the last point should be equal to the first point to indicate that the polyline is closed.
     constructor({
         points,
         lengths,
@@ -33,7 +32,7 @@ export default class Polyline extends TID300Measurement {
         super();
 
         this.points = points;
-        this.lengths = lengths; // Array of lengths between each point
+        this.lengths = lengths;
         this.ReferencedSOPSequence = ReferencedSOPSequence;
         this.use3DSpatialCoordinates = use3DSpatialCoordinates;
     }


### PR DESCRIPTION
### What
Creating adapters for MicroscopyViewer.

### Why
There is a necessity to generate a report based on the tool the user selected [Box, Line, etc] and then retrieve it back.

An example page was built to generate the report (write): https://github.com/dcmjs-org/dcmjs-examples/blob/microscopy-example/microscopy/generateReport/index.html

and another one to read the report genereated
![updaload sample 1](https://user-images.githubusercontent.com/1713255/54792143-a9510d00-4c1b-11e9-84a9-bfad136de80d.gif)

or read a default report just for test case
![upload sample 2](https://user-images.githubusercontent.com/1713255/54792157-b5d56580-4c1b-11e9-94e0-63af12e1c28d.gif)



