### PR TITLE
Referenced instance sequence fix

### DIFF
--- a/examples/createSegmentation/index.html
+++ b/examples/createSegmentation/index.html
@@ -93,7 +93,7 @@
     <!--
       <script src='node_modules/react-viewerbase/dist/index.js'></script>!
     -->
-    <script src="https://unpkg.com/react-cornerstone-viewport/dist/index.umd.js"></script>
+    <script src="https://unpkg.com/react-cornerstone-viewport@0.1.23/dist/index.umd.js"></script>
 
     <script>
       let metaData = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs",
-  "version": "0.3.7",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Javascript implementation of DICOM manipulation",
   "main": "build/dcmjs.js",
   "module": "build/dcmjs.es.js",

--- a/src/derivations/Segmentation.js
+++ b/src/derivations/Segmentation.js
@@ -210,7 +210,7 @@ export default class Segmentation extends DerivedPixels {
                     ];
 
                 ReferencedSOPClassUID =
-                    referencedInstanceSequenceI.ReferencedSOPClass;
+                    referencedInstanceSequenceI.ReferencedSOPClassUID;
                 ReferencedSOPInstanceUID =
                     referencedInstanceSequenceI.ReferencedSOPInstanceUID;
 

--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -276,7 +276,7 @@ class ImageNormalizer extends Normalizer {
             });
 
             ds.ReferencedSeriesSequence.ReferencedInstanceSequence.push({
-                ReferencedSOPClass: dataset.SOPClassUID,
+                ReferencedSOPClassUID: dataset.SOPClassUID,
                 ReferencedSOPInstanceUID: dataset.SOPInstanceUID
             });
         });


### PR DESCRIPTION
`ReferencedSOPClass` -> `ReferencedSOPClassUID` in a few places. Previously some derived exports had an erroneous field when exported.