### PR TITLE
Implementation of Structured Reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
@@ -19,20 +19,20 @@
       "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
-        "@babel/helpers": "^7.2.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/template": "^7.2.2",
-        "@babel/traverse": "^7.2.2",
-        "@babel/types": "^7.2.2",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.10",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.3.2",
+        "@babel/helpers": "7.3.1",
+        "@babel/parser": "7.3.2",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2",
+        "convert-source-map": "1.5.1",
+        "debug": "4.1.1",
+        "json5": "2.1.0",
+        "lodash": "4.17.10",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -41,7 +41,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "json5": {
@@ -50,7 +50,7 @@
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.0"
           }
         },
         "minimist": {
@@ -73,11 +73,11 @@
       "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.2",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.10",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.3.2",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.10",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -94,7 +94,7 @@
       "integrity": "sha512-3UYcJUj9kvSLbLbUIfQTqzcy5VX7GRZ/CCDrnOaZorFFM01aXp1+GJwuFGV4NDDoAS+mOUyHcO6UD/RfqOks3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -103,8 +103,8 @@
       "integrity": "sha512-qNSR4jrmJ8M1VMM9tibvyRAHXQs2PmaksQF7c1CGJNipfe3D8p+wgNwgso/P2A2r2mdgBWAXljNWR0QRZAMW8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-explode-assignable-expression": "7.1.0",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-call-delegate": {
@@ -113,9 +113,9 @@
       "integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-define-map": {
@@ -124,9 +124,9 @@
       "integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/types": "7.3.2",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-explode-assignable-expression": {
@@ -135,8 +135,8 @@
       "integrity": "sha512-NRQpfHrJ1msCHtKjbzs9YcMmJZOg6mQMmGRB+hbamEdG5PNpaSm95275VD92DvJKuyl0s2sFiDmMZ+EnnvufqA==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-function-name": {
@@ -145,9 +145,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -156,7 +156,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -165,7 +165,7 @@
       "integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -174,7 +174,7 @@
       "integrity": "sha512-avo+lm/QmZlv27Zsi0xEor2fKcqWG56D5ae9dzklpIaY7cQMK5N8VSpaNVPPagiqmy7LrEjK1IWdGMOqPu5csg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-module-imports": {
@@ -183,7 +183,7 @@
       "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-module-transforms": {
@@ -192,12 +192,12 @@
       "integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/template": "^7.2.2",
-        "@babel/types": "^7.2.2",
-        "lodash": "^4.17.10"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.2",
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -206,7 +206,7 @@
       "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -221,7 +221,7 @@
       "integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "@babel/helper-remap-async-to-generator": {
@@ -230,11 +230,11 @@
       "integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-wrap-function": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-wrap-function": "7.2.0",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-replace-supers": {
@@ -243,10 +243,10 @@
       "integrity": "sha512-GyieIznGUfPXPWu0yLS6U55Mz67AZD9cUk0BfirOWlPrXlBcan9Gz+vHGz+cPfuoweZSnPzPIm67VtQM0OWZbA==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.0.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.2.3",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-member-expression-to-functions": "7.0.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-simple-access": {
@@ -255,8 +255,8 @@
       "integrity": "sha512-Vk+78hNjRbsiu49zAPALxTb+JUQCz1aolpd8osOF16BGnLtseD21nbHgLPGUwrXEurZgiCOUmvs3ExTu4F5x6w==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/template": "7.2.2",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -265,7 +265,7 @@
       "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helper-wrap-function": {
@@ -274,10 +274,10 @@
       "integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/template": "^7.1.0",
-        "@babel/traverse": "^7.1.0",
-        "@babel/types": "^7.2.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/helpers": {
@@ -286,9 +286,9 @@
       "integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.1.2",
-        "@babel/traverse": "^7.1.5",
-        "@babel/types": "^7.3.0"
+        "@babel/template": "7.2.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/highlight": {
@@ -297,9 +297,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.2",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -308,7 +308,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -317,9 +317,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "js-tokens": {
@@ -334,7 +334,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -351,9 +351,9 @@
       "integrity": "sha512-+Dfo/SCQqrwx48ptLVGLdE39YtWRuKc/Y9I5Fy0P1DDBB9lsAHpjcEJQt+4IifuSOSTLBKJObJqMvaO1pIE8LQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0",
+        "@babel/plugin-syntax-async-generators": "7.2.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {
@@ -362,8 +362,8 @@
       "integrity": "sha512-MAFV1CA/YVmYwZG0fBQyXhmj0BHCB5egZHCKWIFVv/XCxAeVGIHfos3SwDck4LvCllENIAg7xMKOG5kH0dzyUg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-json-strings": "7.2.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
@@ -372,8 +372,8 @@
       "integrity": "sha512-DjeMS+J2+lpANkYLLO+m6GjoTMygYglKmRe6cDTbFv3L9i6mmiE8fe6B8MtCSLZpVXscD5kn7s6SgtHrDoBWoA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -382,8 +382,8 @@
       "integrity": "sha512-mgYj3jCcxug6KUcX4OBoOJz3CMrwRfQELPQ5560F70YQUBZB7uac9fqaWamKR1iWUzGiK2t0ygzjTScZnVz75g==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
@@ -392,9 +392,9 @@
       "integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.2.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.4.0"
       },
       "dependencies": {
         "jsesc": {
@@ -409,12 +409,12 @@
           "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
           "dev": true,
           "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^7.0.0",
-            "regjsgen": "^0.5.0",
-            "regjsparser": "^0.6.0",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.0.2"
+            "regenerate": "1.4.0",
+            "regenerate-unicode-properties": "7.0.0",
+            "regjsgen": "0.5.0",
+            "regjsparser": "0.6.0",
+            "unicode-match-property-ecmascript": "1.0.4",
+            "unicode-match-property-value-ecmascript": "1.0.2"
           }
         },
         "regjsgen": {
@@ -429,7 +429,7 @@
           "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -440,7 +440,7 @@
       "integrity": "sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -449,7 +449,7 @@
       "integrity": "sha512-5UGYnMSLRE1dqqZwug+1LISpA403HzlSfsg6P9VXU6TBjcSHeNlw4DxDx7LgpF+iKZoOG/+uzqoRHTdcUpiZNg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -458,7 +458,7 @@
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-syntax-optional-catch-binding": {
@@ -467,7 +467,7 @@
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -476,7 +476,7 @@
       "integrity": "sha512-ER77Cax1+8/8jCB9fo4Ud161OZzWN5qawi4GusDuRLcDbDG+bIGYY20zb2dfAFdTRGzrfq2xZPvF0R64EHnimg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
@@ -485,9 +485,9 @@
       "integrity": "sha512-CEHzg4g5UraReozI9D4fblBYABs7IM6UerAVG7EJVrTLC5keh00aEuLUT+O40+mJCEzaXkYfTCUKIyeDfMOFFQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-remap-async-to-generator": "^7.1.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-remap-async-to-generator": "7.1.0"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
@@ -496,7 +496,7 @@
       "integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-block-scoping": {
@@ -505,8 +505,8 @@
       "integrity": "sha512-vDTgf19ZEV6mx35yiPJe4fS02mPQUUcBNwWQSZFXSzTSbsJFQvHt7DqyS3LK8oOWALFOsJ+8bbqBgkirZteD5Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "lodash": "^4.17.10"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "lodash": "4.17.10"
       }
     },
     "@babel/plugin-transform-classes": {
@@ -515,14 +515,14 @@
       "integrity": "sha512-gEZvgTy1VtcDOaQty1l10T3jQmJKlNVxLDCs+3rCVPr6nMkODLELxViq5X9l+rfxbie3XrfrMCYYY6eX3aOcOQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-define-map": "^7.1.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "globals": "^11.1.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-define-map": "7.1.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-optimise-call-expression": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.2.3",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "globals": "11.11.0"
       },
       "dependencies": {
         "globals": {
@@ -539,7 +539,7 @@
       "integrity": "sha512-kP/drqTxY6Xt3NNpKiMomfgkNn4o7+vKxK2DDKcBG9sHj51vHqMBGy8wbDS/J4lMxnqs153/T3+DmCEAkC5cpA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -548,7 +548,7 @@
       "integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -557,9 +557,9 @@
       "integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.4.0"
       },
       "dependencies": {
         "jsesc": {
@@ -574,12 +574,12 @@
           "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
           "dev": true,
           "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^7.0.0",
-            "regjsgen": "^0.5.0",
-            "regjsparser": "^0.6.0",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.0.2"
+            "regenerate": "1.4.0",
+            "regenerate-unicode-properties": "7.0.0",
+            "regjsgen": "0.5.0",
+            "regjsparser": "0.6.0",
+            "unicode-match-property-ecmascript": "1.0.4",
+            "unicode-match-property-value-ecmascript": "1.0.2"
           }
         },
         "regjsgen": {
@@ -594,7 +594,7 @@
           "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -605,7 +605,7 @@
       "integrity": "sha512-q+yuxW4DsTjNceUiTzK0L+AfQ0zD9rWaTLiUqHA8p0gxx7lu1EylenfzjeIWNkPy6e/0VG/Wjw9uf9LueQwLOw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
@@ -614,8 +614,8 @@
       "integrity": "sha512-umh4hR6N7mu4Elq9GG8TOu9M0bakvlsREEC+ialrQN6ABS4oDQ69qJv1VtR3uxlKMCQMCvzk7vr17RHKcjx68A==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -624,7 +624,7 @@
       "integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -633,8 +633,8 @@
       "integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-literals": {
@@ -643,7 +643,7 @@
       "integrity": "sha512-2ThDhm4lI4oV7fVQ6pNNK+sx+c/GM5/SaML0w/r4ZB7sAneD/piDJtwdKlNckXeyGK7wlwg2E2w33C/Hh+VFCg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-amd": {
@@ -652,8 +652,8 @@
       "integrity": "sha512-mK2A8ucqz1qhrdqjS9VMIDfIvvT2thrEsIQzbaTdc5QFzhDjQv2CkJJ5f6BXIkgbmaoax3zBr2RyvV/8zeoUZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.2.2",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
@@ -662,9 +662,9 @@
       "integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-simple-access": "^7.1.0"
+        "@babel/helper-module-transforms": "7.2.2",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-simple-access": "7.1.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
@@ -673,8 +673,8 @@
       "integrity": "sha512-aYJwpAhoK9a+1+O625WIjvMY11wkB/ok0WClVwmeo3mCjcNRjt+/8gHWrB5i+00mUju0gWsBkQnPpdvQ7PImmQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-hoist-variables": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -683,8 +683,8 @@
       "integrity": "sha512-BV3bw6MyUH1iIsGhXlOK6sXhmSarZjtJ/vMiD9dNmpY8QXFFQTj+6v92pcfy1iqa8DeAfJFwoxcrS/TUZda6sw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.1.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-module-transforms": "7.2.2",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
@@ -693,7 +693,7 @@
       "integrity": "sha512-NxIoNVhk9ZxS+9lSoAQ/LM0V2UEvARLttEHUrRDGKFaAxOYQcrkN/nLRE+BbbicCAvZPl7wMP0X60HsHE5DtQw==",
       "dev": true,
       "requires": {
-        "regexp-tree": "^0.1.0"
+        "regexp-tree": "0.1.1"
       }
     },
     "@babel/plugin-transform-new-target": {
@@ -702,7 +702,7 @@
       "integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-object-super": {
@@ -711,8 +711,8 @@
       "integrity": "sha512-VMyhPYZISFZAqAPVkiYb7dUe2AsVi2/wCT5+wZdsNO31FojQJa9ns40hzZ6U9f50Jlq4w6qwzdBB2uwqZ00ebg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.1.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-replace-supers": "7.2.3"
       }
     },
     "@babel/plugin-transform-parameters": {
@@ -721,9 +721,9 @@
       "integrity": "sha512-kB9+hhUidIgUoBQ0MsxMewhzr8i60nMa2KgeJKQWYrqQpqcBYtnpR+JgkadZVZoaEZ/eKu9mclFaVwhRpLNSzA==",
       "dev": true,
       "requires": {
-        "@babel/helper-call-delegate": "^7.1.0",
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-call-delegate": "7.1.0",
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -732,7 +732,7 @@
       "integrity": "sha512-sj2qzsEx8KDVv1QuJc/dEfilkg3RRPvPYx/VnKLtItVQRWt1Wqf5eVCOLZm29CiGFfYYsA3VPjfizTCV0S0Dlw==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.13.3"
+        "regenerator-transform": "0.13.3"
       },
       "dependencies": {
         "regenerator-transform": {
@@ -741,7 +741,7 @@
           "integrity": "sha512-5ipTrZFSq5vU2YoGoww4uaRVAK4wyYC4TSICibbfEPOruUu8FFP7ErV0BjmbIOEpn3O/k9na9UEdYR/3m7N6uA==",
           "dev": true,
           "requires": {
-            "private": "^0.1.6"
+            "private": "0.1.8"
           }
         }
       }
@@ -752,7 +752,7 @@
       "integrity": "sha512-QP4eUM83ha9zmYtpbnyjTLAGKQritA5XW/iG9cjtuOI8s1RuL/3V6a3DeSHfKutJQ+ayUfeZJPcnCYEQzaPQqg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-spread": {
@@ -761,7 +761,7 @@
       "integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
@@ -770,8 +770,8 @@
       "integrity": "sha512-KKYCoGaRAf+ckH8gEL3JHUaFVyNHKe3ASNsZ+AlktgHevvxGigoIttrEJb8iKN03Q7Eazlv1s6cx2B2cQ3Jabw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0"
       }
     },
     "@babel/plugin-transform-template-literals": {
@@ -780,8 +780,8 @@
       "integrity": "sha512-FkPix00J9A/XWXv4VoKJBMeSkyY9x/TqIh76wzcdfl57RJJcf8CehQ08uwfhCDNtRQYtHQKBTwKZDEyjE13Lwg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-annotate-as-pure": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -790,7 +790,7 @@
       "integrity": "sha512-2LNhETWYxiYysBtrBTqL8+La0jIoQQnIScUJc74OYvUGRmkskNY4EzLCnjHBzdmb38wqtTaixpo1NctEcvMDZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
@@ -799,9 +799,9 @@
       "integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-regex": "^7.0.0",
-        "regexpu-core": "^4.1.3"
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/helper-regex": "7.0.0",
+        "regexpu-core": "4.4.0"
       },
       "dependencies": {
         "jsesc": {
@@ -816,12 +816,12 @@
           "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
           "dev": true,
           "requires": {
-            "regenerate": "^1.4.0",
-            "regenerate-unicode-properties": "^7.0.0",
-            "regjsgen": "^0.5.0",
-            "regjsparser": "^0.6.0",
-            "unicode-match-property-ecmascript": "^1.0.4",
-            "unicode-match-property-value-ecmascript": "^1.0.2"
+            "regenerate": "1.4.0",
+            "regenerate-unicode-properties": "7.0.0",
+            "regjsgen": "0.5.0",
+            "regjsparser": "0.6.0",
+            "unicode-match-property-ecmascript": "1.0.4",
+            "unicode-match-property-value-ecmascript": "1.0.2"
           }
         },
         "regjsgen": {
@@ -836,7 +836,7 @@
           "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         }
       }
@@ -846,8 +846,8 @@
       "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
       "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
       "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.12.1"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -863,49 +863,49 @@
       "integrity": "sha512-FHKrD6Dxf30e8xgHQO0zJZpUPfVZg+Xwgz5/RdSWCbza9QLNk4Qbp40ctRoqDxml3O8RMzB1DU55SXeDG6PqHQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-        "@babel/plugin-proposal-json-strings": "^7.2.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
-        "@babel/plugin-syntax-async-generators": "^7.2.0",
-        "@babel/plugin-syntax-json-strings": "^7.2.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-        "@babel/plugin-transform-arrow-functions": "^7.2.0",
-        "@babel/plugin-transform-async-to-generator": "^7.2.0",
-        "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-        "@babel/plugin-transform-block-scoping": "^7.2.0",
-        "@babel/plugin-transform-classes": "^7.2.0",
-        "@babel/plugin-transform-computed-properties": "^7.2.0",
-        "@babel/plugin-transform-destructuring": "^7.2.0",
-        "@babel/plugin-transform-dotall-regex": "^7.2.0",
-        "@babel/plugin-transform-duplicate-keys": "^7.2.0",
-        "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-        "@babel/plugin-transform-for-of": "^7.2.0",
-        "@babel/plugin-transform-function-name": "^7.2.0",
-        "@babel/plugin-transform-literals": "^7.2.0",
-        "@babel/plugin-transform-modules-amd": "^7.2.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.2.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.2.0",
-        "@babel/plugin-transform-modules-umd": "^7.2.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
-        "@babel/plugin-transform-new-target": "^7.0.0",
-        "@babel/plugin-transform-object-super": "^7.2.0",
-        "@babel/plugin-transform-parameters": "^7.2.0",
-        "@babel/plugin-transform-regenerator": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.2.0",
-        "@babel/plugin-transform-spread": "^7.2.0",
-        "@babel/plugin-transform-sticky-regex": "^7.2.0",
-        "@babel/plugin-transform-template-literals": "^7.2.0",
-        "@babel/plugin-transform-typeof-symbol": "^7.2.0",
-        "@babel/plugin-transform-unicode-regex": "^7.2.0",
-        "browserslist": "^4.3.4",
-        "invariant": "^2.2.2",
-        "js-levenshtein": "^1.1.3",
-        "semver": "^5.3.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "@babel/helper-plugin-utils": "7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "7.2.0",
+        "@babel/plugin-proposal-json-strings": "7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "7.3.2",
+        "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
+        "@babel/plugin-proposal-unicode-property-regex": "7.2.0",
+        "@babel/plugin-syntax-async-generators": "7.2.0",
+        "@babel/plugin-syntax-json-strings": "7.2.0",
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
+        "@babel/plugin-transform-arrow-functions": "7.2.0",
+        "@babel/plugin-transform-async-to-generator": "7.2.0",
+        "@babel/plugin-transform-block-scoped-functions": "7.2.0",
+        "@babel/plugin-transform-block-scoping": "7.2.0",
+        "@babel/plugin-transform-classes": "7.2.2",
+        "@babel/plugin-transform-computed-properties": "7.2.0",
+        "@babel/plugin-transform-destructuring": "7.3.2",
+        "@babel/plugin-transform-dotall-regex": "7.2.0",
+        "@babel/plugin-transform-duplicate-keys": "7.2.0",
+        "@babel/plugin-transform-exponentiation-operator": "7.2.0",
+        "@babel/plugin-transform-for-of": "7.2.0",
+        "@babel/plugin-transform-function-name": "7.2.0",
+        "@babel/plugin-transform-literals": "7.2.0",
+        "@babel/plugin-transform-modules-amd": "7.2.0",
+        "@babel/plugin-transform-modules-commonjs": "7.2.0",
+        "@babel/plugin-transform-modules-systemjs": "7.2.0",
+        "@babel/plugin-transform-modules-umd": "7.2.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "7.3.0",
+        "@babel/plugin-transform-new-target": "7.0.0",
+        "@babel/plugin-transform-object-super": "7.2.0",
+        "@babel/plugin-transform-parameters": "7.2.0",
+        "@babel/plugin-transform-regenerator": "7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "7.2.0",
+        "@babel/plugin-transform-spread": "7.2.2",
+        "@babel/plugin-transform-sticky-regex": "7.2.0",
+        "@babel/plugin-transform-template-literals": "7.2.0",
+        "@babel/plugin-transform-typeof-symbol": "7.2.0",
+        "@babel/plugin-transform-unicode-regex": "7.2.0",
+        "browserslist": "4.4.1",
+        "invariant": "2.2.4",
+        "js-levenshtein": "1.1.6",
+        "semver": "5.6.0"
       }
     },
     "@babel/runtime": {
@@ -913,7 +913,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
       "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "0.12.1"
       },
       "dependencies": {
         "regenerator-runtime": {
@@ -929,9 +929,9 @@
       "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.3.2",
+        "@babel/types": "7.3.2"
       }
     },
     "@babel/traverse": {
@@ -940,15 +940,15 @@
       "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.2.2",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.2.3",
-        "@babel/types": "^7.2.2",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.10"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.3.2",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.0.0",
+        "@babel/parser": "7.3.2",
+        "@babel/types": "7.3.2",
+        "debug": "4.1.1",
+        "globals": "11.11.0",
+        "lodash": "4.17.10"
       },
       "dependencies": {
         "debug": {
@@ -957,7 +957,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "globals": {
@@ -980,9 +980,9 @@
       "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.10",
+        "to-fast-properties": "2.0.0"
       },
       "dependencies": {
         "to-fast-properties": {
@@ -999,14 +999,14 @@
       "integrity": "sha512-IJyxQWsYDEkf8C8QthBn5N8tIUR9V9je6j3sMIpAkonaadjbvxmRC6RAhpa3RKxndhNnU2M6iNbtJwd7usQYIA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "2.3.0",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "figures": {
@@ -1015,8 +1015,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "log-symbols": {
@@ -1025,7 +1025,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         }
       }
@@ -1036,7 +1036,7 @@
       "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
       "dev": true,
       "requires": {
-        "any-observable": "^0.3.0"
+        "any-observable": "0.3.0"
       }
     },
     "@types/estree": {
@@ -1057,7 +1057,7 @@
       "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
       "dev": true,
       "requires": {
-        "xtend": "~3.0.0"
+        "xtend": "3.0.0"
       },
       "dependencies": {
         "xtend": {
@@ -1086,10 +1086,10 @@
       "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ansi-escapes": {
@@ -1122,7 +1122,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1149,7 +1149,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -1176,9 +1176,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "assign-symbols": {
@@ -1205,12 +1205,12 @@
       "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.3.2",
+        "@babel/traverse": "7.2.3",
+        "@babel/types": "7.3.2",
         "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
         "eslint-scope": {
@@ -1219,8 +1219,8 @@
           "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
           "dev": true,
           "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
           }
         }
       }
@@ -1237,13 +1237,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1252,7 +1252,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1261,7 +1261,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1270,7 +1270,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1279,9 +1279,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1292,7 +1292,7 @@
       "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.26"
+        "readable-stream": "1.0.34"
       }
     },
     "bn.js": {
@@ -1307,7 +1307,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1317,16 +1317,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1335,7 +1335,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1352,12 +1352,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-cipher": {
@@ -1366,9 +1366,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
+        "browserify-aes": "1.2.0",
+        "browserify-des": "1.0.2",
+        "evp_bytestokey": "1.0.3"
       }
     },
     "browserify-des": {
@@ -1377,10 +1377,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "browserify-fs": {
@@ -1389,9 +1389,9 @@
       "integrity": "sha1-8HWqinKdTRcW0GZiDjhvzBMRqW8=",
       "dev": true,
       "requires": {
-        "level-filesystem": "^1.0.1",
-        "level-js": "^2.1.3",
-        "levelup": "^0.18.2"
+        "level-filesystem": "1.2.0",
+        "level-js": "2.2.4",
+        "levelup": "0.18.6"
       }
     },
     "browserify-rsa": {
@@ -1400,8 +1400,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
+        "bn.js": "4.11.8",
+        "randombytes": "2.1.0"
       }
     },
     "browserify-sign": {
@@ -1410,13 +1410,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "elliptic": "6.4.1",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.4"
       }
     },
     "browserslist": {
@@ -1425,9 +1425,9 @@
       "integrity": "sha512-pEBxEXg7JwaakBXjATYw/D1YZh4QUSCX/Mnd/wnqSRPPSi1U39iDhDoKGoBUcraKdxDlrYqJxSI5nNvD+dWP2A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000929",
-        "electron-to-chromium": "^1.3.103",
-        "node-releases": "^1.1.3"
+        "caniuse-lite": "1.0.30000938",
+        "electron-to-chromium": "1.3.113",
+        "node-releases": "1.1.7"
       }
     },
     "buffer-es6": {
@@ -1460,15 +1460,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "caller-callsite": {
@@ -1477,7 +1477,7 @@
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
-        "callsites": "^2.0.0"
+        "callsites": "2.0.0"
       },
       "dependencies": {
         "callsites": {
@@ -1494,7 +1494,7 @@
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
-        "caller-callsite": "^2.0.0"
+        "caller-callsite": "2.0.0"
       }
     },
     "callsites": {
@@ -1521,11 +1521,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "chardet": {
@@ -1546,8 +1546,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "circular-json": {
@@ -1562,10 +1562,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -1574,7 +1574,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -1585,7 +1585,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-table3": {
@@ -1594,9 +1594,9 @@
       "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
-        "object-assign": "^4.1.0",
-        "string-width": "^2.1.1"
+        "colors": "1.3.3",
+        "object-assign": "4.1.1",
+        "string-width": "2.1.1"
       }
     },
     "cli-truncate": {
@@ -1606,7 +1606,7 @@
       "dev": true,
       "requires": {
         "slice-ansi": "0.0.4",
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -1615,7 +1615,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "slice-ansi": {
@@ -1630,9 +1630,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -1649,9 +1649,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1666,7 +1666,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1689,8 +1689,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1738,10 +1738,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -1750,13 +1750,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         }
       }
@@ -1790,10 +1790,10 @@
       "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
       "dev": true,
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "parse-json": "^4.0.0"
+        "import-fresh": "2.0.0",
+        "is-directory": "0.3.1",
+        "js-yaml": "3.12.1",
+        "parse-json": "4.0.0"
       },
       "dependencies": {
         "import-fresh": {
@@ -1802,8 +1802,8 @@
           "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
           "dev": true,
           "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
+            "caller-path": "2.0.0",
+            "resolve-from": "3.0.0"
           }
         }
       }
@@ -1814,8 +1814,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
+        "bn.js": "4.11.8",
+        "elliptic": "6.4.1"
       }
     },
     "create-hash": {
@@ -1824,11 +1824,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.5",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -1837,12 +1837,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
@@ -1851,11 +1851,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.6.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-browserify": {
@@ -1864,17 +1864,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "1.0.1",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.3",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "diffie-hellman": "5.0.3",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.17",
+        "public-encrypt": "4.0.3",
+        "randombytes": "2.1.0",
+        "randomfill": "1.0.4"
       }
     },
     "date-fns": {
@@ -1922,7 +1922,7 @@
       "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "~0.12.1"
+        "abstract-leveldown": "0.12.4"
       }
     },
     "define-property": {
@@ -1931,8 +1931,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1941,7 +1941,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1950,7 +1950,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1959,9 +1959,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1972,12 +1972,12 @@
       "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "6.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "p-map": "1.2.0",
+        "pify": "3.0.0",
+        "rimraf": "2.6.2"
       }
     },
     "des.js": {
@@ -1986,8 +1986,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "diffie-hellman": {
@@ -1996,9 +1996,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
+        "bn.js": "4.11.8",
+        "miller-rabin": "4.0.1",
+        "randombytes": "2.1.0"
       }
     },
     "doctrine": {
@@ -2007,7 +2007,7 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2"
+        "esutils": "2.0.2"
       }
     },
     "electron-to-chromium": {
@@ -2028,13 +2028,13 @@
       "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.7",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "emoji-regex": {
@@ -2049,7 +2049,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "errno": {
@@ -2058,7 +2058,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -2067,7 +2067,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -2082,42 +2082,42 @@
       "integrity": "sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.5.3",
-        "chalk": "^2.1.0",
-        "cross-spawn": "^6.0.5",
-        "debug": "^4.0.1",
-        "doctrine": "^2.1.0",
-        "eslint-scope": "^4.0.0",
-        "eslint-utils": "^1.3.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^5.0.0",
-        "esquery": "^1.0.1",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "functional-red-black-tree": "^1.0.1",
-        "glob": "^7.1.2",
-        "globals": "^11.7.0",
-        "ignore": "^4.0.6",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^6.1.0",
-        "js-yaml": "^3.12.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.3.0",
-        "lodash": "^4.17.5",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.2",
-        "progress": "^2.0.0",
-        "regexpp": "^2.0.1",
-        "semver": "^5.5.1",
-        "strip-ansi": "^4.0.0",
-        "strip-json-comments": "^2.0.1",
-        "table": "^5.0.2",
-        "text-table": "^0.2.0"
+        "@babel/code-frame": "7.0.0",
+        "ajv": "6.5.3",
+        "chalk": "2.4.2",
+        "cross-spawn": "6.0.5",
+        "debug": "4.1.1",
+        "doctrine": "2.1.0",
+        "eslint-scope": "4.0.0",
+        "eslint-utils": "1.3.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "5.0.0",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.11.0",
+        "ignore": "4.0.6",
+        "import-fresh": "3.0.0",
+        "imurmurhash": "0.1.4",
+        "inquirer": "6.2.2",
+        "js-yaml": "3.12.1",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.10",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "progress": "2.0.3",
+        "regexpp": "2.0.1",
+        "semver": "5.6.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "5.2.3",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2132,7 +2132,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -2141,9 +2141,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "debug": {
@@ -2152,7 +2152,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "globals": {
@@ -2173,7 +2173,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "supports-color": {
@@ -2182,7 +2182,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2193,8 +2193,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
       }
     },
     "eslint-utils": {
@@ -2215,9 +2215,9 @@
       "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.2",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "6.1.0",
+        "acorn-jsx": "5.0.1",
+        "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -2240,7 +2240,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -2249,7 +2249,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "4.2.0"
       }
     },
     "estraverse": {
@@ -2276,8 +2276,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.5",
+        "safe-buffer": "5.1.2"
       }
     },
     "execa": {
@@ -2286,13 +2286,13 @@
       "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "expand-brackets": {
@@ -2301,13 +2301,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -2316,7 +2316,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -2325,7 +2325,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2336,7 +2336,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.4"
       },
       "dependencies": {
         "fill-range": {
@@ -2345,11 +2345,11 @@
           "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
           "dev": true,
           "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "3.1.1",
+            "repeat-element": "1.1.3",
+            "repeat-string": "1.6.1"
           }
         },
         "is-number": {
@@ -2358,7 +2358,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "isobject": {
@@ -2376,7 +2376,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -2387,8 +2387,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2397,7 +2397,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2408,9 +2408,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
+        "chardet": "0.7.0",
+        "iconv-lite": "0.4.24",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -2419,14 +2419,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -2435,7 +2435,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -2444,7 +2444,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -2453,7 +2453,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -2462,7 +2462,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -2471,9 +2471,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -2502,7 +2502,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2511,8 +2511,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.4",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -2527,10 +2527,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -2539,7 +2539,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -2556,10 +2556,10 @@
       "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "graceful-fs": "^4.1.2",
-        "rimraf": "~2.6.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "graceful-fs": "4.1.11",
+        "rimraf": "2.6.2",
+        "write": "0.2.1"
       }
     },
     "fn-name": {
@@ -2580,7 +2580,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "foreach": {
@@ -2595,7 +2595,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fs.realpath": {
@@ -2616,7 +2616,7 @@
       "integrity": "sha1-7Sgcq+1G/uz5Ie4y3ExQs3KsfPo=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.26-4"
+        "readable-stream": "1.0.34"
       }
     },
     "g-status": {
@@ -2625,9 +2625,9 @@
       "integrity": "sha512-kQoE9qH+T1AHKgSSD0Hkv98bobE90ILQcXAF4wvGgsr7uFqNvwmh8j+Lq3l0RVt3E3HjSbv2B9biEGcEtpHLCA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "matcher": "^1.0.0",
-        "simple-git": "^1.85.0"
+        "arrify": "1.0.1",
+        "matcher": "1.1.1",
+        "simple-git": "1.107.0"
       }
     },
     "get-caller-file": {
@@ -2666,12 +2666,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -2680,8 +2680,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "glob-parent": {
@@ -2690,7 +2690,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "^2.0.0"
+            "is-glob": "2.0.1"
           }
         },
         "is-extglob": {
@@ -2705,7 +2705,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -2716,11 +2716,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -2743,7 +2743,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -2758,9 +2758,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -2769,8 +2769,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -2779,7 +2779,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -2790,8 +2790,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -2800,8 +2800,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hmac-drbg": {
@@ -2810,9 +2810,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.7",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hosted-git-info": {
@@ -2827,16 +2827,16 @@
       "integrity": "sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^5.0.7",
-        "execa": "^1.0.0",
-        "find-up": "^3.0.0",
-        "get-stdin": "^6.0.0",
-        "is-ci": "^2.0.0",
-        "pkg-dir": "^3.0.0",
-        "please-upgrade-node": "^3.1.1",
-        "read-pkg": "^4.0.1",
-        "run-node": "^1.0.0",
-        "slash": "^2.0.0"
+        "cosmiconfig": "5.0.7",
+        "execa": "1.0.0",
+        "find-up": "3.0.0",
+        "get-stdin": "6.0.0",
+        "is-ci": "2.0.0",
+        "pkg-dir": "3.0.0",
+        "please-upgrade-node": "3.1.1",
+        "read-pkg": "4.0.1",
+        "run-node": "1.0.0",
+        "slash": "2.0.0"
       },
       "dependencies": {
         "execa": {
@@ -2845,13 +2845,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "find-up": {
@@ -2860,7 +2860,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "get-stream": {
@@ -2869,7 +2869,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         },
         "locate-path": {
@@ -2878,8 +2878,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -2888,7 +2888,7 @@
           "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.0.0"
           }
         },
         "p-locate": {
@@ -2897,7 +2897,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.1.0"
           }
         },
         "p-try": {
@@ -2912,7 +2912,7 @@
           "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "3.0.0"
           }
         },
         "pump": {
@@ -2921,8 +2921,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "slash": {
@@ -2939,7 +2939,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "idb-wrapper": {
@@ -2960,8 +2960,8 @@
       "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
       "dev": true,
       "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
+        "parent-module": "1.0.0",
+        "resolve-from": "4.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -2996,8 +2996,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -3012,19 +3012,19 @@
       "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-width": "^2.0.0",
-        "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.11",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "3.0.3",
+        "figures": "2.0.0",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
-        "run-async": "^2.2.0",
-        "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
-        "through": "^2.3.6"
+        "run-async": "2.3.0",
+        "rxjs": "6.4.0",
+        "string-width": "2.1.1",
+        "strip-ansi": "5.0.0",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3039,7 +3039,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -3048,9 +3048,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "lodash": {
@@ -3065,7 +3065,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           }
         },
         "supports-color": {
@@ -3074,7 +3074,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3085,7 +3085,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -3111,7 +3111,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3120,7 +3120,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3142,7 +3142,7 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "^2.0.0"
+        "ci-info": "2.0.0"
       }
     },
     "is-data-descriptor": {
@@ -3151,7 +3151,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3160,7 +3160,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3171,9 +3171,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -3202,7 +3202,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-extendable": {
@@ -3229,7 +3229,7 @@
       "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-module": {
@@ -3244,7 +3244,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3253,7 +3253,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3276,7 +3276,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "^1.1.0"
+        "symbol-observable": "1.2.0"
       }
     },
     "is-path-cwd": {
@@ -3291,7 +3291,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
@@ -3300,7 +3300,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-object": {
@@ -3309,7 +3309,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-posix-bracket": {
@@ -3390,8 +3390,8 @@
       "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "json-parse-better-errors": {
@@ -3424,7 +3424,7 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "level-blobs": {
@@ -3434,8 +3434,8 @@
       "dev": true,
       "requires": {
         "level-peek": "1.0.6",
-        "once": "^1.3.0",
-        "readable-stream": "^1.0.26-4"
+        "once": "1.4.0",
+        "readable-stream": "1.0.34"
       }
     },
     "level-filesystem": {
@@ -3444,15 +3444,15 @@
       "integrity": "sha1-oArKmRnEpN+v3KaoEI0iWq3/Y7M=",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.4",
-        "errno": "^0.1.1",
-        "fwd-stream": "^1.0.4",
-        "level-blobs": "^0.1.7",
-        "level-peek": "^1.0.6",
-        "level-sublevel": "^5.2.0",
-        "octal": "^1.0.0",
-        "once": "^1.3.0",
-        "xtend": "^2.2.0"
+        "concat-stream": "1.6.2",
+        "errno": "0.1.7",
+        "fwd-stream": "1.0.4",
+        "level-blobs": "0.1.7",
+        "level-peek": "1.0.6",
+        "level-sublevel": "5.2.3",
+        "octal": "1.0.0",
+        "once": "1.4.0",
+        "xtend": "2.2.0"
       },
       "dependencies": {
         "xtend": {
@@ -3475,7 +3475,7 @@
       "integrity": "sha1-G5rmGSKTDzMF0aYfxNg8gQLA3ZM=",
       "dev": true,
       "requires": {
-        "string-range": "~1.2"
+        "string-range": "1.2.2"
       }
     },
     "level-js": {
@@ -3484,12 +3484,12 @@
       "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "~0.12.0",
-        "idb-wrapper": "^1.5.0",
-        "isbuffer": "~0.0.0",
-        "ltgt": "^2.1.2",
-        "typedarray-to-buffer": "~1.0.0",
-        "xtend": "~2.1.2"
+        "abstract-leveldown": "0.12.4",
+        "idb-wrapper": "1.7.2",
+        "isbuffer": "0.0.0",
+        "ltgt": "2.2.1",
+        "typedarray-to-buffer": "1.0.4",
+        "xtend": "2.1.2"
       }
     },
     "level-peek": {
@@ -3498,7 +3498,7 @@
       "integrity": "sha1-vsUccqgu5GTTNkNMfIdsP8vM538=",
       "dev": true,
       "requires": {
-        "level-fix-range": "~1.0.2"
+        "level-fix-range": "1.0.2"
       }
     },
     "level-sublevel": {
@@ -3507,10 +3507,10 @@
       "integrity": "sha1-dEwSxy0ucr543eO5tc2E1iGRQTo=",
       "dev": true,
       "requires": {
-        "level-fix-range": "2.0",
-        "level-hooks": ">=4.4.0 <5",
-        "string-range": "~1.2.1",
-        "xtend": "~2.0.4"
+        "level-fix-range": "2.0.0",
+        "level-hooks": "4.5.0",
+        "string-range": "1.2.2",
+        "xtend": "2.0.6"
       },
       "dependencies": {
         "level-fix-range": {
@@ -3519,7 +3519,7 @@
           "integrity": "sha1-xBfWIVlEIVGhnZojZ4aPFyTC1Ug=",
           "dev": true,
           "requires": {
-            "clone": "~0.1.9"
+            "clone": "0.1.19"
           }
         },
         "object-keys": {
@@ -3528,9 +3528,9 @@
           "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
           "dev": true,
           "requires": {
-            "foreach": "~2.0.1",
-            "indexof": "~0.0.1",
-            "is": "~0.2.6"
+            "foreach": "2.0.5",
+            "indexof": "0.0.1",
+            "is": "0.2.7"
           }
         },
         "xtend": {
@@ -3539,8 +3539,8 @@
           "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
           "dev": true,
           "requires": {
-            "is-object": "~0.1.2",
-            "object-keys": "~0.2.0"
+            "is-object": "0.1.2",
+            "object-keys": "0.2.0"
           }
         }
       }
@@ -3551,13 +3551,13 @@
       "integrity": "sha1-5qAcsIlhbI7MApHCqb0/DETj5es=",
       "dev": true,
       "requires": {
-        "bl": "~0.8.1",
-        "deferred-leveldown": "~0.2.0",
-        "errno": "~0.1.1",
-        "prr": "~0.0.0",
-        "readable-stream": "~1.0.26",
-        "semver": "~2.3.1",
-        "xtend": "~3.0.0"
+        "bl": "0.8.2",
+        "deferred-leveldown": "0.2.0",
+        "errno": "0.1.7",
+        "prr": "0.0.0",
+        "readable-stream": "1.0.34",
+        "semver": "2.3.2",
+        "xtend": "3.0.0"
       },
       "dependencies": {
         "prr": {
@@ -3586,8 +3586,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lint-staged": {
@@ -3597,30 +3597,30 @@
       "dev": true,
       "requires": {
         "@iamstarkov/listr-update-renderer": "0.4.1",
-        "chalk": "^2.3.1",
-        "commander": "^2.14.1",
-        "cosmiconfig": "^5.0.2",
-        "debug": "^3.1.0",
-        "dedent": "^0.7.0",
-        "del": "^3.0.0",
-        "execa": "^1.0.0",
-        "find-parent-dir": "^0.3.0",
-        "g-status": "^2.0.2",
-        "is-glob": "^4.0.0",
-        "is-windows": "^1.0.2",
-        "listr": "^0.14.2",
-        "lodash": "^4.17.11",
-        "log-symbols": "^2.2.0",
-        "micromatch": "^3.1.8",
-        "npm-which": "^3.0.1",
-        "p-map": "^1.1.1",
-        "path-is-inside": "^1.0.2",
-        "pify": "^3.0.0",
-        "please-upgrade-node": "^3.0.2",
+        "chalk": "2.4.2",
+        "commander": "2.19.0",
+        "cosmiconfig": "5.0.7",
+        "debug": "3.2.6",
+        "dedent": "0.7.0",
+        "del": "3.0.0",
+        "execa": "1.0.0",
+        "find-parent-dir": "0.3.0",
+        "g-status": "2.0.2",
+        "is-glob": "4.0.0",
+        "is-windows": "1.0.2",
+        "listr": "0.14.3",
+        "lodash": "4.17.11",
+        "log-symbols": "2.2.0",
+        "micromatch": "3.1.10",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "please-upgrade-node": "3.1.1",
         "staged-git-files": "1.1.2",
-        "string-argv": "^0.0.2",
-        "stringify-object": "^3.2.2",
-        "yup": "^0.26.10"
+        "string-argv": "0.0.2",
+        "stringify-object": "3.3.0",
+        "yup": "0.26.10"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3629,7 +3629,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -3638,9 +3638,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "commander": {
@@ -3655,7 +3655,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "execa": {
@@ -3664,13 +3664,13 @@
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
           "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^4.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "6.0.5",
+            "get-stream": "4.1.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "get-stream": {
@@ -3679,7 +3679,7 @@
           "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         },
         "lodash": {
@@ -3700,8 +3700,8 @@
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "supports-color": {
@@ -3710,7 +3710,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3721,15 +3721,15 @@
       "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
       "dev": true,
       "requires": {
-        "@samverschueren/stream-to-observable": "^0.3.0",
-        "is-observable": "^1.1.0",
-        "is-promise": "^2.1.0",
-        "is-stream": "^1.1.0",
-        "listr-silent-renderer": "^1.1.1",
-        "listr-update-renderer": "^0.5.0",
-        "listr-verbose-renderer": "^0.5.0",
-        "p-map": "^2.0.0",
-        "rxjs": "^6.3.3"
+        "@samverschueren/stream-to-observable": "0.3.0",
+        "is-observable": "1.1.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.5.0",
+        "listr-verbose-renderer": "0.5.0",
+        "p-map": "2.0.0",
+        "rxjs": "6.4.0"
       },
       "dependencies": {
         "p-map": {
@@ -3752,14 +3752,14 @@
       "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "cli-truncate": "^0.2.1",
-        "elegant-spinner": "^1.0.1",
-        "figures": "^1.7.0",
-        "indent-string": "^3.0.0",
-        "log-symbols": "^1.0.2",
-        "log-update": "^2.3.0",
-        "strip-ansi": "^3.0.1"
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "2.3.0",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "figures": {
@@ -3768,8 +3768,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "log-symbols": {
@@ -3778,7 +3778,7 @@
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
-            "chalk": "^1.0.0"
+            "chalk": "1.1.3"
           }
         }
       }
@@ -3789,10 +3789,10 @@
       "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "cli-cursor": "^2.1.0",
-        "date-fns": "^1.27.2",
-        "figures": "^2.0.0"
+        "chalk": "2.4.2",
+        "cli-cursor": "2.1.0",
+        "date-fns": "1.30.1",
+        "figures": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3801,7 +3801,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -3810,9 +3810,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "supports-color": {
@@ -3821,7 +3821,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3838,7 +3838,7 @@
       "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.4.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3847,7 +3847,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -3856,9 +3856,9 @@
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "supports-color": {
@@ -3867,7 +3867,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -3878,9 +3878,9 @@
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.0.0",
-        "cli-cursor": "^2.0.0",
-        "wrap-ansi": "^3.0.1"
+        "ansi-escapes": "3.2.0",
+        "cli-cursor": "2.1.0",
+        "wrap-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3895,7 +3895,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         },
         "wrap-ansi": {
@@ -3904,8 +3904,8 @@
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0"
           }
         }
       }
@@ -3921,7 +3921,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "ltgt": {
@@ -3936,7 +3936,7 @@
       "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "1.4.4"
       }
     },
     "map-age-cleaner": {
@@ -3945,7 +3945,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -3960,7 +3960,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "matcher": {
@@ -3969,7 +3969,7 @@
       "integrity": "sha512-+BmqxWIubKTRKNWx/ahnCkk3mG8m7OturVlqq6HiojGJTd5hVYbgZm6WzcYPCoB+KBT4Vd6R7WSRG2OADNaCjg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "math-random": {
@@ -3984,9 +3984,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "mem": {
@@ -3995,9 +3995,9 @@
       "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
-        "p-is-promise": "^1.1.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "1.2.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "micromatch": {
@@ -4006,19 +4006,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "miller-rabin": {
@@ -4027,8 +4027,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0"
       }
     },
     "mimic-fn": {
@@ -4055,7 +4055,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -4070,8 +4070,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -4080,7 +4080,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -4112,17 +4112,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "natural-compare": {
@@ -4136,8 +4136,8 @@
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
       "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
       "requires": {
-        "iota-array": "^1.0.0",
-        "is-buffer": "^1.0.2"
+        "iota-array": "1.0.0",
+        "is-buffer": "1.1.6"
       }
     },
     "nice-try": {
@@ -4152,7 +4152,7 @@
       "integrity": "sha512-bKdrwaqJUPHqlCzDD7so/R+Nk0jGv9a11ZhLrD9f6i947qGLrGAhU3OxRENa19QQmwzGy/g6zCDEuLGDO8HPvA==",
       "dev": true,
       "requires": {
-        "semver": "^5.3.0"
+        "semver": "5.6.0"
       }
     },
     "normalize-package-data": {
@@ -4161,10 +4161,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -4173,7 +4173,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-path": {
@@ -4182,7 +4182,7 @@
       "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
       "dev": true,
       "requires": {
-        "which": "^1.2.10"
+        "which": "1.3.1"
       }
     },
     "npm-run-path": {
@@ -4191,7 +4191,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "npm-which": {
@@ -4200,9 +4200,9 @@
       "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
       "dev": true,
       "requires": {
-        "commander": "^2.9.0",
-        "npm-path": "^2.0.2",
-        "which": "^1.2.10"
+        "commander": "2.13.0",
+        "npm-path": "2.0.4",
+        "which": "1.3.1"
       }
     },
     "number-is-nan": {
@@ -4223,9 +4223,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -4234,7 +4234,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -4243,7 +4243,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4254,7 +4254,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.omit": {
@@ -4263,8 +4263,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "object.pick": {
@@ -4273,7 +4273,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "octal": {
@@ -4288,7 +4288,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -4297,7 +4297,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "optionator": {
@@ -4306,12 +4306,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-locale": {
@@ -4320,9 +4320,9 @@
       "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
       "dev": true,
       "requires": {
-        "execa": "^0.10.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "0.10.0",
+        "lcid": "2.0.0",
+        "mem": "4.0.0"
       }
     },
     "os-tmpdir": {
@@ -4361,7 +4361,7 @@
       "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
       "dev": true,
       "requires": {
-        "callsites": "^3.0.0"
+        "callsites": "3.0.0"
       }
     },
     "parse-asn1": {
@@ -4370,12 +4370,12 @@
       "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "dev": true,
       "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
+        "asn1.js": "4.10.1",
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "pbkdf2": "3.0.17",
+        "safe-buffer": "5.1.2"
       }
     },
     "parse-glob": {
@@ -4384,10 +4384,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       },
       "dependencies": {
         "is-extglob": {
@@ -4402,7 +4402,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         }
       }
@@ -4413,8 +4413,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "pascalcase": {
@@ -4459,11 +4459,11 @@
       "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "pify": {
@@ -4484,7 +4484,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "please-upgrade-node": {
@@ -4493,7 +4493,7 @@
       "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
       "dev": true,
       "requires": {
-        "semver-compare": "^1.0.0"
+        "semver-compare": "1.0.0"
       }
     },
     "posix-character-classes": {
@@ -4562,12 +4562,12 @@
       "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "bn.js": "4.11.8",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.2.0",
+        "parse-asn1": "5.1.4",
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "punycode": {
@@ -4582,9 +4582,9 @@
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.4"
       },
       "dependencies": {
         "is-number": {
@@ -4601,7 +4601,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "randomfill": {
@@ -4610,8 +4610,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "read-pkg": {
@@ -4620,9 +4620,9 @@
       "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
       "dev": true,
       "requires": {
-        "normalize-package-data": "^2.3.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0"
+        "normalize-package-data": "2.5.0",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0"
       }
     },
     "readable-stream": {
@@ -4631,10 +4631,10 @@
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
         "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "string_decoder": "0.10.31"
       },
       "dependencies": {
         "isarray": {
@@ -4663,7 +4663,7 @@
       "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
       "dev": true,
       "requires": {
-        "regenerate": "^1.4.0"
+        "regenerate": "1.4.0"
       }
     },
     "regex-cache": {
@@ -4672,7 +4672,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regex-not": {
@@ -4681,8 +4681,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "regexp-tree": {
@@ -4691,9 +4691,9 @@
       "integrity": "sha512-HwRjOquc9QOwKTgbxvZTcddS5mlNlwePMQ3NFL8broajMLD5CXDAqas8Y5yxJH5QtZp5iRor3YCILd5pz71Cgw==",
       "dev": true,
       "requires": {
-        "cli-table3": "^0.5.0",
-        "colors": "^1.1.2",
-        "yargs": "^12.0.5"
+        "cli-table3": "0.5.1",
+        "colors": "1.3.3",
+        "yargs": "12.0.5"
       }
     },
     "regexpp": {
@@ -4738,7 +4738,7 @@
       "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-from": {
@@ -4759,8 +4759,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "ret": {
@@ -4775,7 +4775,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "ripemd160": {
@@ -4784,8 +4784,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "rollup": {
@@ -4795,8 +4795,8 @@
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*",
-        "acorn": "^6.0.5"
+        "@types/node": "11.9.4",
+        "acorn": "6.1.0"
       },
       "dependencies": {
         "acorn": {
@@ -4813,8 +4813,8 @@
       "integrity": "sha512-KfnizE258L/4enADKX61ozfwGHoqYauvoofghFJBhFnpH9Sb9dNPpWg8QHOaAfVASUYV8w0mCx430i9z0LJoJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "rollup-pluginutils": "^2.3.0"
+        "@babel/helper-module-imports": "7.0.0",
+        "rollup-pluginutils": "2.3.3"
       }
     },
     "rollup-plugin-commonjs": {
@@ -4823,10 +4823,10 @@
       "integrity": "sha512-0RM5U4Vd6iHjL6rLvr3lKBwnPsaVml+qxOGaaNUWN1lSq6S33KhITOfHmvxV3z2vy9Mk4t0g4rNlVaJJsNQPWA==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.5.2",
-        "magic-string": "^0.25.1",
-        "resolve": "^1.8.1",
-        "rollup-pluginutils": "^2.3.3"
+        "estree-walker": "0.5.2",
+        "magic-string": "0.25.2",
+        "resolve": "1.10.0",
+        "rollup-pluginutils": "2.3.3"
       }
     },
     "rollup-plugin-json": {
@@ -4835,7 +4835,7 @@
       "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
       "dev": true,
       "requires": {
-        "rollup-pluginutils": "^2.3.1"
+        "rollup-pluginutils": "2.3.3"
       }
     },
     "rollup-plugin-node-builtins": {
@@ -4844,10 +4844,10 @@
       "integrity": "sha1-JKH+1KQyV7a2Q3HYq8bOGrFFl+k=",
       "dev": true,
       "requires": {
-        "browserify-fs": "^1.0.0",
-        "buffer-es6": "^4.9.2",
-        "crypto-browserify": "^3.11.0",
-        "process-es6": "^0.11.2"
+        "browserify-fs": "1.0.0",
+        "buffer-es6": "4.9.3",
+        "crypto-browserify": "3.12.0",
+        "process-es6": "0.11.6"
       }
     },
     "rollup-plugin-node-globals": {
@@ -4856,12 +4856,12 @@
       "integrity": "sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==",
       "dev": true,
       "requires": {
-        "acorn": "^5.7.3",
-        "buffer-es6": "^4.9.3",
-        "estree-walker": "^0.5.2",
-        "magic-string": "^0.22.5",
-        "process-es6": "^0.11.6",
-        "rollup-pluginutils": "^2.3.1"
+        "acorn": "5.7.3",
+        "buffer-es6": "4.9.3",
+        "estree-walker": "0.5.2",
+        "magic-string": "0.22.5",
+        "process-es6": "0.11.6",
+        "rollup-pluginutils": "2.3.3"
       },
       "dependencies": {
         "magic-string": {
@@ -4870,7 +4870,7 @@
           "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
           "dev": true,
           "requires": {
-            "vlq": "^0.2.2"
+            "vlq": "0.2.3"
           }
         }
       }
@@ -4881,9 +4881,9 @@
       "integrity": "sha512-7Ni+/M5RPSUBfUaP9alwYQiIKnKeXCOHiqBpKUl9kwp3jX5ZJtgXAait1cne6pGEVUUztPD6skIKH9Kq9sNtfw==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^3.0.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.8.1"
+        "builtin-modules": "3.0.0",
+        "is-module": "1.0.0",
+        "resolve": "1.10.0"
       }
     },
     "rollup-pluginutils": {
@@ -4892,8 +4892,8 @@
       "integrity": "sha512-2XZwja7b6P5q4RZ5FhyX1+f46xi1Z3qBKigLRZ6VTZjwbN0K1IFGMlwm06Uu0Emcre2Z63l77nq/pzn+KxIEoA==",
       "dev": true,
       "requires": {
-        "estree-walker": "^0.5.2",
-        "micromatch": "^2.3.11"
+        "estree-walker": "0.5.2",
+        "micromatch": "2.3.11"
       },
       "dependencies": {
         "arr-diff": {
@@ -4902,7 +4902,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "arr-flatten": "1.1.0"
           }
         },
         "array-unique": {
@@ -4917,9 +4917,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.3"
           }
         },
         "expand-brackets": {
@@ -4928,7 +4928,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
+            "is-posix-bracket": "0.1.1"
           }
         },
         "extglob": {
@@ -4937,7 +4937,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "is-extglob": {
@@ -4952,7 +4952,7 @@
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
-            "is-extglob": "^1.0.0"
+            "is-extglob": "1.0.0"
           }
         },
         "kind-of": {
@@ -4961,7 +4961,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "micromatch": {
@@ -4970,19 +4970,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.4"
           }
         }
       }
@@ -4993,7 +4993,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "is-promise": "2.1.0"
       }
     },
     "run-node": {
@@ -5008,7 +5008,7 @@
       "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "1.9.3"
       }
     },
     "safe-buffer": {
@@ -5023,7 +5023,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -5056,10 +5056,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5068,7 +5068,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5079,8 +5079,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "shebang-command": {
@@ -5089,7 +5089,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -5110,7 +5110,7 @@
       "integrity": "sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==",
       "dev": true,
       "requires": {
-        "debug": "^4.0.1"
+        "debug": "4.1.1"
       },
       "dependencies": {
         "debug": {
@@ -5119,7 +5119,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -5136,9 +5136,9 @@
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "3.2.1",
+        "astral-regex": "1.0.0",
+        "is-fullwidth-code-point": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5147,7 +5147,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         }
       }
@@ -5158,14 +5158,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -5174,7 +5174,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -5183,7 +5183,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -5194,9 +5194,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -5205,7 +5205,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -5214,7 +5214,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -5223,7 +5223,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -5232,9 +5232,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -5245,7 +5245,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5254,7 +5254,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5271,11 +5271,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-url": {
@@ -5296,8 +5296,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-exceptions": {
@@ -5312,8 +5312,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-license-ids": {
@@ -5328,7 +5328,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -5349,8 +5349,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -5359,7 +5359,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -5382,8 +5382,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5398,7 +5398,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -5409,7 +5409,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringify-object": {
@@ -5418,9 +5418,9 @@
       "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
       "dev": true,
       "requires": {
-        "get-own-enumerable-property-symbols": "^3.0.0",
-        "is-obj": "^1.0.1",
-        "is-regexp": "^1.0.0"
+        "get-own-enumerable-property-symbols": "3.0.0",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
       }
     },
     "strip-ansi": {
@@ -5429,7 +5429,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-eof": {
@@ -5468,10 +5468,10 @@
       "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
       "dev": true,
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "6.9.1",
+        "lodash": "4.17.11",
+        "slice-ansi": "2.1.0",
+        "string-width": "3.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -5480,10 +5480,10 @@
           "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-regex": {
@@ -5504,9 +5504,9 @@
           "integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.0.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.0.0"
           }
         },
         "strip-ansi": {
@@ -5515,7 +5515,7 @@
           "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "4.0.0"
           }
         }
       }
@@ -5538,7 +5538,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-object-path": {
@@ -5547,7 +5547,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -5556,7 +5556,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -5567,10 +5567,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -5579,8 +5579,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "toposort": {
@@ -5607,7 +5607,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -5634,8 +5634,8 @@
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "dev": true,
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
+        "unicode-canonical-property-names-ecmascript": "1.0.4",
+        "unicode-property-aliases-ecmascript": "1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -5656,10 +5656,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -5668,7 +5668,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -5677,10 +5677,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -5691,8 +5691,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -5701,9 +5701,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -5731,7 +5731,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -5758,8 +5758,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "vlq": {
@@ -5774,7 +5774,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -5795,8 +5795,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -5805,7 +5805,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -5814,9 +5814,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         }
       }
@@ -5833,7 +5833,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       }
     },
     "xtend": {
@@ -5842,7 +5842,7 @@
       "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
       "dev": true,
       "requires": {
-        "object-keys": "~0.4.0"
+        "object-keys": "0.4.0"
       },
       "dependencies": {
         "object-keys": {
@@ -5865,18 +5865,18 @@
       "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "3.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "11.1.1"
       },
       "dependencies": {
         "find-up": {
@@ -5885,7 +5885,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -5894,8 +5894,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -5904,7 +5904,7 @@
           "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.0.0"
           }
         },
         "p-locate": {
@@ -5913,7 +5913,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.0.0"
           }
         },
         "p-try": {
@@ -5930,8 +5930,8 @@
       "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.0.0",
+        "decamelize": "1.2.0"
       }
     },
     "yup": {
@@ -5941,11 +5941,11 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "7.0.0",
-        "fn-name": "~2.0.1",
-        "lodash": "^4.17.10",
-        "property-expr": "^1.5.0",
-        "synchronous-promise": "^2.0.5",
-        "toposort": "^2.0.2"
+        "fn-name": "2.0.1",
+        "lodash": "4.17.10",
+        "property-expr": "1.5.1",
+        "synchronous-promise": "2.0.6",
+        "toposort": "2.0.2"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -5954,7 +5954,7 @@
           "integrity": "sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==",
           "dev": true,
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "0.12.1"
           }
         },
         "regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "description": "Javascript implementation of DICOM manipulation",
   "main": "build/dcmjs.js",
   "module": "build/dcmjs.es.js",

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -144,7 +144,7 @@ class DicomMetaDictionary {
             var entry = DicomMetaDictionary.nameMap[name];
             if (entry) {
                 let dataValue = dataset[naturalName];
-                if (dataValue === undefined || dataValue === null) {
+                if (dataValue === undefined) {
                     // handle the case where it was deleted from the object but is in keys
                     return;
                 }

--- a/src/datasetToBlob.js
+++ b/src/datasetToBlob.js
@@ -1,24 +1,22 @@
 import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
 import { DicomDict } from "./DicomDict.js";
 
-function datasetToDict(dataset) {
-    const meta = {
-        FileMetaInformationVersion:
-            dataset._meta.FileMetaInformationVersion.Value,
+function datasetToDict(dataset, transferSyntaxUID = "1.2.840.10008.1.2.1") {
+    const fileMetaInformationVersionArray = new Uint8Array(2);
+    fileMetaInformationVersionArray[1] = 1;
+    dataset._meta = {
         MediaStorageSOPClassUID: dataset.SOPClassUID,
         MediaStorageSOPInstanceUID: dataset.SOPInstanceUID,
-        TransferSyntaxUID: "1.2.840.10008.1.2",
-        ImplementationClassUID: DicomMetaDictionary.uid(),
-        ImplementationVersionName: "dcmjs-0.0"
+        ImplementationVersionName: "dcmjs-0.0",
+        TransferSyntaxUID: transferSyntaxUID,
+        ImplementationClassUID:
+            "2.25.80302813137786398554742050926734630921603366648225212145404",
+        FileMetaInformationVersion: fileMetaInformationVersionArray.buffer
     };
 
-    // TODO: Clean this up later
-    if (!meta.FileMetaInformationVersion) {
-        meta.FileMetaInformationVersion =
-            dataset._meta.FileMetaInformationVersion.Value[0];
-    }
-
-    const denaturalized = DicomMetaDictionary.denaturalizeDataset(meta);
+    const denaturalized = DicomMetaDictionary.denaturalizeDataset(
+        dataset._meta
+    );
     const dicomDict = new DicomDict(denaturalized);
     dicomDict.dict = DicomMetaDictionary.denaturalizeDataset(dataset);
     return dicomDict;

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,9 @@ export { normalizers };
 
 import adapters from "./adapters/index.js";
 import utilities from "./utilities/index.js";
+import sr from "./sr/index.js";
 
 export { adapters };
 export { utilities };
 export { DICOMWEB };
+export { sr };

--- a/src/sr/coding.js
+++ b/src/sr/coding.js
@@ -1,0 +1,77 @@
+class Code {
+    constructor(options) {
+        this[_value] = options.value;
+        this[_meaning] = options.meaning;
+        this[_schemeDesignator] = options.schemeDesignator;
+        this[_schemeVersion] = options.schemeVersion || null;
+    }
+
+    get value() {
+        return this[_value];
+    }
+
+    get meaning() {
+        return this[_meaning];
+    }
+
+    get schemeDesignator() {
+        return this[_schemeDesignator];
+    }
+
+    get schemeVersion() {
+        return this[_schemeVersion];
+    }
+}
+
+class CodedConcept {
+    constructor(options) {
+        if (options.value === undefined) {
+            throw new Error("Option 'value' is required for CodedConcept.");
+        }
+        if (options.meaning === undefined) {
+            throw new Error("Option 'meaning' is required for CodedConcept.");
+        }
+        if (options.schemeDesignator === undefined) {
+            throw new Error(
+                "Option 'schemeDesignator' is required for CodedConcept."
+            );
+        }
+        this.CodeValue = options.value;
+        this.CodeMeaning = options.meaning;
+        this.CodingSchemeDesignator = options.schemeDesignator;
+        if ("schemeVersion" in options) {
+            this.CodingSchemeVersion = options.schemeVersion;
+        }
+    }
+
+    equals(other) {
+        if (
+            other.value === this.value &&
+            other.schemeDesignator === this.schemeDesignator
+        ) {
+            if (other.schemeVersion && this.schemeVersion) {
+                return other.schemeVersion === this.schemeVersion;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    get value() {
+        return this.CodeValue;
+    }
+
+    get meaning() {
+        return this.CodeMeaning;
+    }
+
+    get schemeDesignator() {
+        return this.CodingSchemeDesignator;
+    }
+
+    get schemeVersion() {
+        return this.CodingSchemeVersion;
+    }
+}
+
+export { Code, CodedConcept };

--- a/src/sr/contentItems.js
+++ b/src/sr/contentItems.js
@@ -1,0 +1,384 @@
+import { CodedConcept } from "./coding.js";
+import {
+    CodeContentItem,
+    CompositeContentItem,
+    ContentSequence,
+    GraphicTypes,
+    GraphicTypes3D,
+    ImageContentItem,
+    NumContentItem,
+    PixelOriginInterpretations,
+    RelationshipTypes,
+    ScoordContentItem,
+    Scoord3DContentItem,
+    UIDRefContentItem
+} from "./valueTypes.js";
+
+class LongitudinalTemporalOffsetFromEvent extends NumContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "128740",
+                meaning: "Longitudinal Temporal Offset from Event",
+                schemeDesignator: "DCM"
+            }),
+            value: options.value,
+            unit: options.unit,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.ContentSequence = new ContentSequence();
+        const item = new CodeContentItem({
+            name: new CodedConcept({
+                value: "128741",
+                meaning: "Longitudinal Temporal Event Type",
+                schemeDesignator: "DCM"
+            }),
+            value: options.eventType,
+            relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+        });
+        this.ContentSequence.push(item);
+    }
+}
+
+class SourceImageForRegion extends ImageContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "121324",
+                meaning: "Source Image",
+                schemeDesignator: "DCM"
+            }),
+            referencedSOPClassUID: options.referencedSOPClassUID,
+            referencedSOPInstanceUID: options.referencedSOPInstanceUID,
+            referencedFrameNumbers: options.referencedFrameNumbers,
+            relationshipType: RelationshipTypes.SELECTED_FROM
+        });
+    }
+}
+
+class SourceImageForSegmentation extends ImageContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "121233",
+                meaning: "Source Image for Segmentation",
+                schemeDesignator: "DCM"
+            }),
+            referencedSOPClassUID: options.referencedSOPClassUID,
+            referencedSOPInstanceUID: options.referencedSOPInstanceUID,
+            referencedFrameNumbers: options.referencedFrameNumbers,
+            relationshipType: RelationshipTypes.SELECTED_FROM
+        });
+    }
+}
+
+class SourceSeriesForSegmentation extends UIDRefContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "121232",
+                meaning: "Source Series for Segmentation",
+                schemeDesignator: "DCM"
+            }),
+            value: options.referencedSeriesInstanceUID,
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+    }
+}
+
+class ImageRegion extends ScoordContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "111030",
+                meaning: "Image Region",
+                schemeDesignator: "DCM"
+            }),
+            graphicType: options.graphicType,
+            graphicData: options.graphicData,
+            pixelOriginInterpretation: options.pixelOriginInterpretation,
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+        if (options.graphicType === GraphicTypes.MULTIPOINT) {
+            throw new Error(
+                "Graphic type 'MULTIPOINT' is not valid for region."
+            );
+        }
+        if (options.sourceImage === undefined) {
+            throw Error("Option 'sourceImage' is required for ImageRegion.");
+        }
+        if (
+            !(
+                options.sourceImage ||
+                options.sourceImage.constructor === SourceImageForRegion
+            )
+        ) {
+            throw new Error(
+                "Option 'sourceImage' of ImageRegion must have type " +
+                    "SourceImageForRegion."
+            );
+        }
+        this.ContentSequence = new ContentSequence();
+        this.ContentSequence.push(options.sourceImage);
+    }
+}
+
+class ImageRegion3D extends Scoord3DContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "111030",
+                meaning: "Image Region",
+                schemeDesignator: "DCM"
+            }),
+            graphicType: options.graphicType,
+            graphicData: options.graphicData,
+            frameOfReferenceUID: options.frameOfReferenceUID,
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+        if (options.graphicType === GraphicTypes3D.MULTIPOINT) {
+            throw new Error(
+                "Graphic type 'MULTIPOINT' is not valid for region."
+            );
+        }
+        if (options.graphicType === GraphicTypes3D.ELLIPSOID) {
+            throw new Error(
+                "Graphic type 'ELLIPSOID' is not valid for region."
+            );
+        }
+    }
+}
+
+class VolumeSurface extends Scoord3DContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "121231",
+                meaning: "Volume Surface",
+                schemeDesignator: "DCM"
+            }),
+            graphicType: options.graphicType,
+            graphicData: options.graphicData,
+            frameOfFeferenceUID: options.frameOfFeferenceUID,
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+        if (options.graphicType !== GraphicTypes3D.ELLIPSOID) {
+            throw new Error(
+                "Graphic type for volume surface must be 'ELLIPSOID'."
+            );
+        }
+        this.ContentSequence = new ContentSequence();
+        if (options.sourceImages) {
+            options.sourceImages.forEach(image => {
+                if (!(image || image.constructor === SourceImageForRegion)) {
+                    throw new Error(
+                        "Items of option 'sourceImages' of VolumeSurface " +
+                            "must have type SourceImageForRegion."
+                    );
+                }
+                this.ContentSequence.push(image);
+            });
+        } else if (options.sourceSeries) {
+            if (
+                !(
+                    options.sourceSeries ||
+                    options.sourceSeries.constructor === SourceSeriesForRegion
+                )
+            ) {
+                throw new Error(
+                    "Option 'sourceSeries' of VolumeSurface " +
+                        "must have type SourceSeriesForRegion."
+                );
+            }
+            this.ContentSequence.push(options.sourceSeries);
+        } else {
+            throw new Error(
+                "One of the following two options must be provided: " +
+                    "'sourceImage' or 'sourceSeries'."
+            );
+        }
+    }
+}
+
+class ReferencedRealWorldValueMap extends CompositeContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "126100",
+                meaning: "Real World Value Map used for measurement",
+                schemeDesignator: "DCM"
+            }),
+            referencedSOPClassUID: option.referencedSOPClassUID,
+            referencedSOPInstanceUID: options.referencedSOPInstanceUID,
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+    }
+}
+
+class FindingSite extends CodeContentItem {
+    constructor(options) {
+        super({
+            name: new CodedConcept({
+                value: "363698007",
+                meaning: "Finding Site",
+                schemeDesignator: "SCT"
+            }),
+            value: options.anatomicLocation,
+            relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+        });
+        this.ContentSequence = new ContentSequence();
+        if (options.laterality) {
+            const item = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "272741003",
+                    meaning: "Laterality",
+                    schemeDesignator: "SCT"
+                }),
+                value: options.laterality,
+                relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+            });
+            this.ContentSequence.push(item);
+        }
+        if (options.topographicalModifier) {
+            const item = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "106233006",
+                    meaning: "Topographical Modifier",
+                    schemeDesignator: "SCT"
+                }),
+                value: options.topographicalModifier,
+                relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+            });
+            this.ContentSequence.push(item);
+        }
+    }
+}
+
+class ReferencedSegmentationFrame extends ContentSequence {
+    constructor(options) {
+        if (options.sopClassUID === undefined) {
+            throw new Error(
+                "Option 'sopClassUID' is required for ReferencedSegmentationFrame."
+            );
+        }
+        if (options.sopInstanceUID === undefined) {
+            throw new Error(
+                "Option 'sopInstanceUID' is required for ReferencedSegmentationFrame."
+            );
+        }
+        if (options.frameNumber === undefined) {
+            throw new Error(
+                "Option 'frameNumber' is required for ReferencedSegmentationFrame."
+            );
+        }
+        if (options.segmentNumber === undefined) {
+            throw new Error(
+                "Option 'segmentNumber' is required for ReferencedSegmentationFrame."
+            );
+        }
+        if (options.sourceImage === undefined) {
+            throw new Error(
+                "Option 'sourceImage' is required for ReferencedSegmentationFrame."
+            );
+        }
+        super();
+        const segmentationItem = ImageContentItem({
+            name: new CodedConcept({
+                value: "121214",
+                meaning: "Referenced Segmentation Frame",
+                schemeDesignator: "DCM"
+            }),
+            referencedSOPClassUid: options.sopClassUid,
+            referencedSOPInstanceUid: options.sopInstanceUid,
+            referencedFrameNumber: options.frameNumber,
+            referencedSegmentNumber: options.segmentNumber
+        });
+        this.push(segmentationItem);
+        if (options.sourceImage.constructor !== SourceImageForSegmentation) {
+            throw new Error(
+                "Option 'sourceImage' must have type SourceImageForSegmentation."
+            );
+        }
+        this.push(sourceImage);
+    }
+}
+
+class ReferencedSegmentation extends ContentSequence {
+    constructor(options) {
+        if (options.sopClassUID === undefined) {
+            throw new Error(
+                "Option 'sopClassUID' is required for ReferencedSegmentation."
+            );
+        }
+        if (options.sopInstanceUID === undefined) {
+            throw new Error(
+                "Option 'sopInstanceUID' is required for ReferencedSegmentation."
+            );
+        }
+        if (options.frameNumbers === undefined) {
+            throw new Error(
+                "Option 'frameNumbers' is required for ReferencedSegmentation."
+            );
+        }
+        if (options.segmentNumber === undefined) {
+            throw new Error(
+                "Option 'segmentNumber' is required for ReferencedSegmentation."
+            );
+        }
+        super();
+        const segmentationItem = new ImageContentItem({
+            name: new CodedConcept({
+                value: "121191",
+                meaning: "Referenced Segment",
+                schemeDesignator: "DCM"
+            }),
+            referencedSOPClassUid: options.sopClassUid,
+            referencedSOPInstanceUid: options.sopInstanceUid,
+            referencedFrameNumber: options.frameNumbers,
+            referencedSegmentNumber: options.segmentNumber
+        });
+        this.push(segmentationItem);
+        if (options.sourceImages !== undefined) {
+            options.sourceImages.forEach(image => {
+                if (
+                    !image ||
+                    image.constructor !== SourceImageForSegmentation
+                ) {
+                    throw new Error(
+                        "Items of option 'sourceImages' must have type " +
+                            "SourceImageForSegmentation."
+                    );
+                }
+                this.push(image);
+            });
+        } else if (options.sourceSeries !== undefined) {
+            if (
+                options.sourceSeries.constructor !== SourceSeriesForSegmentation
+            ) {
+                throw new Error(
+                    "Option 'sourceSeries' must have type SourceSeriesForSegmentation."
+                );
+            }
+            this.push(sourceSeries);
+        } else {
+            throw new Error(
+                "One of the following two options must be provided: " +
+                    "'sourceImages' or 'sourceSeries'."
+            );
+        }
+    }
+}
+
+export {
+    FindingSite,
+    LongitudinalTemporalOffsetFromEvent,
+    ReferencedRealWorldValueMap,
+    ImageRegion,
+    ImageRegion3D,
+    ReferencedSegmentation,
+    ReferencedSegmentationFrame,
+    VolumeSurface,
+    SourceImageForRegion,
+    SourceImageForSegmentation,
+    SourceSeriesForSegmentation
+};

--- a/src/sr/documents.js
+++ b/src/sr/documents.js
@@ -1,0 +1,432 @@
+import { DicomMetaDictionary } from "../DicomMetaDictionary.js";
+
+const _attributesToInclude = [
+    // Patient
+    "00080054",
+    "00080100",
+    "00080102",
+    "00080103",
+    "00080104",
+    "00080105",
+    "00080106",
+    "00080107",
+    "0008010B",
+    "0008010D",
+    "0008010F",
+    "00080117",
+    "00080118",
+    "00080119",
+    "00080120",
+    "00080121",
+    "00080122",
+    "00081120",
+    "00081150",
+    "00081155",
+    "00081160",
+    "00081190",
+    "00081199",
+    "00100010",
+    "00100020",
+    "00100021",
+    "00100022",
+    "00100024",
+    "00100026",
+    "00100027",
+    "00100028",
+    "00100030",
+    "00100032",
+    "00100033",
+    "00100034",
+    "00100035",
+    "00100040",
+    "00100200",
+    "00100212",
+    "00100213",
+    "00100214",
+    "00100215",
+    "00100216",
+    "00100217",
+    "00100218",
+    "00100219",
+    "00100221",
+    "00100222",
+    "00100223",
+    "00100229",
+    "00101001",
+    "00101002",
+    "00101100",
+    "00102160",
+    "00102201",
+    "00102202",
+    "00102292",
+    "00102293",
+    "00102294",
+    "00102295",
+    "00102296",
+    "00102297",
+    "00102298",
+    "00102299",
+    "00104000",
+    "00120062",
+    "00120063",
+    "00120064",
+    "0020000D",
+    "00400031",
+    "00400032",
+    "00400033",
+    "00400035",
+    "00400036",
+    "00400039",
+    "0040003A",
+    "0040E001",
+    "0040E010",
+    "0040E020",
+    "0040E021",
+    "0040E022",
+    "0040E023",
+    "0040E024",
+    "0040E025",
+    "0040E030",
+    "0040E031",
+    "0062000B",
+    "00880130",
+    "00880140",
+    // Patient Study
+    "00080100",
+    "00080102",
+    "00080103",
+    "00080104",
+    "00080105",
+    "00080106",
+    "00080107",
+    "0008010B",
+    "0008010D",
+    "0008010F",
+    "00080117",
+    "00080118",
+    "00080119",
+    "00080120",
+    "00080121",
+    "00080122",
+    "00081080",
+    "00081084",
+    "00101010",
+    "00101020",
+    "00101021",
+    "00101022",
+    "00101023",
+    "00101024",
+    "00101030",
+    "00102000",
+    "00102110",
+    "00102180",
+    "001021A0",
+    "001021B0",
+    "001021C0",
+    "001021D0",
+    "00102203",
+    "00380010",
+    "00380014",
+    "00380060",
+    "00380062",
+    "00380064",
+    "00380500",
+    "00400031",
+    "00400032",
+    "00400033",
+    // General Study
+    "00080020",
+    "00080030",
+    "00080050",
+    "00080051",
+    "00080080",
+    "00080081",
+    "00080082",
+    "00080090",
+    "00080096",
+    "0008009C",
+    "0008009D",
+    "00080100",
+    "00080102",
+    "00080103",
+    "00080104",
+    "00080105",
+    "00080106",
+    "00080107",
+    "0008010B",
+    "0008010D",
+    "0008010F",
+    "00080117",
+    "00080118",
+    "00080119",
+    "00080120",
+    "00080121",
+    "00080122",
+    "00081030",
+    "00081032",
+    "00081048",
+    "00081049",
+    "00081060",
+    "00081062",
+    "00081110",
+    "00081150",
+    "00081155",
+    "0020000D",
+    "00200010",
+    "00321034",
+    "00400031",
+    "00400032",
+    "00400033",
+    "00401012",
+    "00401101",
+    "00401102",
+    "00401103",
+    "00401104",
+    // Clinical Trial Subject
+    "00120010",
+    "00120020",
+    "00120021",
+    "00120030",
+    "00120031",
+    "00120040",
+    "00120042",
+    "00120081",
+    "00120082",
+    // Clinical Trial Study
+    "00120020",
+    "00120050",
+    "00120051",
+    "00120052",
+    "00120053",
+    "00120083",
+    "00120084",
+    "00120085"
+];
+
+class Comprehensive3DSR {
+    constructor(options) {
+        if (options.evidence === undefined) {
+            throw new Error(
+                "Option 'evidence' is required for Comprehensive3DSR."
+            );
+        }
+        if (
+            !(
+                typeof options.evidence === "object" ||
+                options.evidence instanceof Array
+            )
+        ) {
+            throw new Error("Option 'evidence' must have type Array.");
+        }
+        if (options.evidence.length === 0) {
+            throw new Error("Option 'evidence' must have non-zero length.");
+        }
+        if (options.content === undefined) {
+            throw new Error(
+                "Option 'content' is required for Comprehensive3DSR."
+            );
+        }
+        if (options.seriesInstanceUID === undefined) {
+            throw new Error(
+                "Option 'seriesInstanceUID' is required for Comprehensive3DSR."
+            );
+        }
+        if (options.seriesNumber === undefined) {
+            throw new Error(
+                "Option 'seriesNumber' is required for Comprehensive3DSR."
+            );
+        }
+        if (options.seriesDescription === undefined) {
+            throw new Error(
+                "Option 'seriesDescription' is required for Comprehensive3DSR."
+            );
+        }
+        if (options.sopInstanceUID === undefined) {
+            throw new Error(
+                "Option 'sopInstanceUID' is required for Comprehensive3DSR."
+            );
+        }
+        if (options.instanceNumber === undefined) {
+            throw new Error(
+                "Option 'instanceNumber' is required for Comprehensive3DSR."
+            );
+        }
+        if (options.manufacturer === undefined) {
+            throw new Error(
+                "Option 'manufacturer' is required for Comprehensive3DSR."
+            );
+        }
+
+        this.SOPClassUID = "1.2.840.10008.5.1.4.1.1.88.34";
+        this.SOPInstanceUID = options.sopInstanceUID;
+        this.Modality = "SR";
+        this.SeriesDescription = options.seriesDescription;
+        this.SeriesInstanceUID = options.seriesInstanceUID;
+        this.SeriesNumber = options.seriesNumber;
+        this.InstanceNumber = options.instanceNumber;
+
+        this.Manufacturer = options.manufacturer;
+        if (options.institutionName !== undefined) {
+            this.InstitutionName = options.institutionName;
+            if (options.institutionalDepartmentName !== undefined) {
+                this.InstitutionalDepartmentName =
+                    options.institutionDepartmentName;
+            }
+        }
+
+        if (options.isComplete) {
+            this.CompletionFlag = "COMPLETE";
+        } else {
+            this.CompletionFlag = "PARTIAL";
+        }
+        if (options.isVerified) {
+            if (options.verifyingObserverName === undefined) {
+                throw new Error(
+                    "Verifying Observer Name must be specified if SR document " +
+                        "has been verified."
+                );
+            }
+            if (options.verifyingOrganization === undefined) {
+                throw new Error(
+                    "Verifying Organization must be specified if SR document " +
+                        "has been verified."
+                );
+            }
+            this.VerificationFlag = "VERIFIED";
+            const ovserver_item = {};
+            ovserver_item.VerifyingObserverName = options.verifyingObserverName;
+            ovserver_item.VerifyingOrganization = options.verifyingOrganization;
+            ovserver_item.VerificationDateTime = DicomMetaDictionary.dateTime();
+            this.VerifyingObserverSequence = [observer_item];
+        } else {
+            this.VerificationFlag = "UNVERIFIED";
+        }
+        if (options.isFinal) {
+            this.PreliminaryFlag = "FINAL";
+        } else {
+            this.PreliminaryFlag = "PRELIMINARY";
+        }
+
+        this.ContentDate = DicomMetaDictionary.date();
+        this.ContentTime = DicomMetaDictionary.time();
+
+        Object.keys(options.content).forEach(keyword => {
+            this[keyword] = options.content[keyword];
+        });
+
+        const evidenceCollection = {};
+        options.evidence.forEach(evidence => {
+            if (
+                evidence.StudyInstanceUID !==
+                options.evidence[0].StudyInstanceUID
+            ) {
+                throw new Error(
+                    "Referenced data sets must all belong to the same study."
+                );
+            }
+            if (!(evidence.SeriesInstanceUID in evidenceCollection)) {
+                evidenceCollection[evidence.SeriesInstanceUID] = [];
+            }
+            const instanceItem = {};
+            instanceItem.ReferencedSOPClassUID = evidence.SOPClassUID;
+            instanceItem.ReferencedSOPInstanceUID = evidence.SOPInstanceUID;
+            evidenceCollection[evidence.SeriesInstanceUID].push(instanceItem);
+        });
+        const evidenceStudyItem = {};
+        evidenceStudyItem.StudyInstanceUID =
+            options.evidence[0].StudyInstanceUID;
+        evidenceStudyItem.ReferencedSeriesSequence = [];
+        Object.keys(evidenceCollection).forEach(seriesInstanceUID => {
+            const seriesItem = {};
+            seriesItem.SeriesInstanceUID = seriesInstanceUID;
+            seriesItem.ReferencedSOPSequence =
+                evidenceCollection[seriesInstanceUID];
+            evidenceStudyItem.ReferencedSeriesSequence.push(seriesItem);
+        });
+
+        if (options.requestedProcedures !== undefined) {
+            if (
+                !(
+                    typeof options.requestedProcedures === "object" ||
+                    options.requestedProcedures instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'requestedProcedures' must have type Array."
+                );
+            }
+            this.ReferencedRequestSequence = new ContentSequence(
+                ...options.requestedProcedures
+            );
+            this.CurrentRequestedProcedureEvidenceSequence = [
+                evidenceStudyItem
+            ];
+        } else {
+            this.PertinentOtherEvidenceSequence = [evidenceStudyItem];
+        }
+
+        if (options.previousVersions !== undefined) {
+            const preCollection = {};
+            options.previousVersions.forEach(version => {
+                if (
+                    version.StudyInstanceUID !=
+                    options.evidence[0].StudyInstanceUID
+                ) {
+                    throw new Error(
+                        "Previous version data sets must belong to the same study."
+                    );
+                }
+                const instanceItem = {};
+                instanceItem.ReferencedSOPClassUID = version.SOPClassUID;
+                instanceItem.ReferencedSOPInstanceUID = version.SOPInstanceUID;
+                preCollection[version.SeriesInstanceUID].push(instanceItem);
+            });
+            const preStudyItem = {};
+            preStudyItem.StudyInstanceUID =
+                options.previousVersions[0].StudyInstanceUID;
+            preStudyItem.ReferencedSeriesSequence = [];
+            Object.keys(preCollection).forEach(seriesInstanceUID => {
+                const seriesItem = {};
+                seriesItem.SeriesInstanceUID = seriesInstanceUID;
+                seriesItem.ReferencedSOPSequence =
+                    preCollection[seriesInstanceUID];
+                preStudyItem.ReferencedSeriesSequence.push(seriesItem);
+            });
+            this.PredecessorDocumentsSequence = [preStudyItem];
+        }
+
+        if (options.performedProcedureCodes !== undefined) {
+            if (
+                !(
+                    typeof options.performedProcedureCodes === "object" ||
+                    options.performedProcedureCodes instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'performedProcedureCodes' must have type Array."
+                );
+            }
+            this.PerformedProcedureCodeSequence = new ContentSequence(
+                ...options.performedProcedureCodes
+            );
+        } else {
+            this.PerformedProcedureCodeSequence = [];
+        }
+
+        this.ReferencedPerformedProcedureStepSequence = [];
+
+        _attributesToInclude.forEach(tag => {
+            const key = DicomMetaDictionary.punctuateTag(tag);
+            const element = DicomMetaDictionary.dictionary[key];
+            if (element !== undefined) {
+                const keyword = element.name;
+                const value = options.evidence[0][keyword];
+                if (value !== undefined) {
+                    this[keyword] = value;
+                }
+            }
+        });
+    }
+}
+
+export { Comprehensive3DSR };

--- a/src/sr/index.js
+++ b/src/sr/index.js
@@ -1,0 +1,15 @@
+import * as coding from "./coding.js";
+import * as contentItems from "./contentItems.js";
+import * as templates from "./templates.js";
+import * as valueTypes from "./valueTypes.js";
+import * as documents from "./documents.js";
+
+const sr = {
+    coding,
+    contentItems,
+    documents,
+    templates,
+    valueTypes
+};
+
+export default sr;

--- a/src/sr/templates.js
+++ b/src/sr/templates.js
@@ -1,0 +1,1615 @@
+import { Code, CodedConcept } from "./coding.js";
+import {
+    CodeContentItem,
+    CompositeContentItem,
+    ContainerContentItem,
+    ContentSequence,
+    GraphicTypes,
+    GraphicTypes3D,
+    ImageContentItem,
+    NumContentItem,
+    PixelOriginInterpretations,
+    PNameContentItem,
+    RelationshipTypes,
+    ScoordContentItem,
+    Scoord3DContentItem,
+    TextContentItem,
+    UIDRefContentItem
+} from "./valueTypes.js";
+import {
+    FindingSite,
+    LongitudinalTemporalOffsetFromEvent,
+    ImageRegion,
+    ImageRegion3D,
+    ReferencedSegmentation,
+    ReferencedSegmentationFrame,
+    VolumeSurface,
+    ReferencedRealWorldValueMap,
+    SourceImageForSegmentation,
+    SourceSeriesForSegmentation
+} from "./contentItems.js";
+
+class Template extends ContentSequence {
+    constructor(...args) {
+        super(...args);
+    }
+}
+
+class Measurement extends Template {
+    constructor(options) {
+        super();
+        const valueItem = new NumContentItem({
+            name: options.name,
+            value: options.value,
+            unit: options.unit,
+            qualifier: options.qualifier,
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+        valueItem.ContentSequence = new ContentSequence();
+        if (options.trackingIdentifier === undefined) {
+            throw new Error(
+                "Option 'trackingIdentifier' is required for Measurement."
+            );
+        }
+        if (options.trackingIdentifier.constructor === TrackingIdentifier) {
+            throw new Error(
+                "Option 'trackingIdentifier' must have type TrackingIdentifier."
+            );
+        }
+        valueItem.ContentSequence.push(...options.trackingIdentifier);
+        if (options.method !== undefined) {
+            const methodItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "370129005",
+                    meaning: "Measurement Method",
+                    schemeDesignator: "SCT"
+                }),
+                value: options.method,
+                relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+            });
+            valueItem.ContentSequence.push(methodItem);
+        }
+        if (options.derivation !== undefined) {
+            const derivationItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121401",
+                    meaning: "Derivation",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.derivation,
+                relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+            });
+            valueItem.ContentSequence.push(derivationItem);
+        }
+        if (options.findingSites !== undefined) {
+            if (
+                !(
+                    typeof options.findingSites === "object" ||
+                    options.findingSites instanceof Array
+                )
+            ) {
+                throw new Error("Option 'findingSites' must have type Array.");
+            }
+            options.findingSites.forEach(site => {
+                if (!site || site.constructor !== FindingSite) {
+                    throw new Error(
+                        "Items of option 'findingSites' must have type FindingSite."
+                    );
+                }
+                valueItem.ContentSequence.push(site);
+            });
+        }
+        if (options.properties !== undefined) {
+            if (options.properties.constructor !== MeasurementProperties) {
+                throw new Error(
+                    "Option 'properties' must have type MeasurementProperties."
+                );
+            }
+            valueItem.ContentSequence.push(...options.properties);
+        }
+        if (options.referencedRegions !== undefined) {
+            if (
+                !(
+                    typeof options.referencedRegions === "object" ||
+                    options.referencedRegions instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedRegions' must have type Array."
+                );
+            }
+            options.referencedRegions.forEach(region => {
+                if (
+                    !region ||
+                    (region.constructor !== ImageRegion &&
+                        region.constructor !== ImageRegion3D)
+                ) {
+                    throw new Error(
+                        "Items of option 'referencedRegion' must have type " +
+                            "ImageRegion or ImageRegion3D."
+                    );
+                }
+                valueItem.ContentSequence.push(region);
+            });
+        } else if (options.referencedVolume !== undefined) {
+            if (options.referencedVolume.constructor !== VolumeSurface) {
+                throw new Error(
+                    "Option 'referencedVolume' must have type VolumeSurface."
+                );
+            }
+            valueItem.ContentSequence.push(options.referencedVolume);
+        } else if (options.referencedSegmentation !== undefined) {
+            if (
+                options.referencedSegmentation.constructor !==
+                    ReferencedSegmentation &&
+                options.referencedSegmentation.constructor !==
+                    ReferencedSegmentationFrame
+            ) {
+                throw new Error(
+                    "Option 'referencedSegmentation' must have type " +
+                        "ReferencedSegmentation or ReferencedSegmentationFrame."
+                );
+            }
+            valueItem.ContentSequence.push(options.referencedSegmentation);
+        }
+        if (options.referencedRealWorldValueMap !== undefined) {
+            if (
+                options.referencedRealWorldValueMap.constructor !==
+                ReferencedRealWorldValueMap
+            ) {
+                throw new Error(
+                    "Option 'referencedRealWorldValueMap' must have type " +
+                        "ReferencedRealWorldValueMap."
+                );
+            }
+            valueItem.ContentSequence.push(options.referencedRealWorldValueMap);
+        }
+        if (options.algorithmId !== undefined) {
+            if (options.algorithmId.constructor !== AlgorithmIdentification) {
+                throw new Error(
+                    "Option 'algorithmId' must have type AlgorithmIdentification."
+                );
+            }
+            valueItem.ContentSequence.push(...options.algorithmId);
+        }
+        this.push(valueItem);
+    }
+}
+
+class MeasurementProperties extends Template {
+    constructor(options) {
+        super();
+        if (options.normality !== undefined) {
+            const normalityItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121402",
+                    schemeDesignator: "DCM",
+                    meaning: "Normality"
+                }),
+                value: options.normality,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(normalityItem);
+        }
+        if (options.measurementStatisticalProperties !== undefined) {
+            if (
+                options.measurementStatisticalProperties.constructor !==
+                MeasurementStatisticalProperties
+            ) {
+                throw new Error(
+                    "Option 'measurmentStatisticalProperties' must have type " +
+                        "MeasurementStatisticalProperties."
+                );
+            }
+            this.push(...measurementStatisticalProperties);
+        }
+        if (options.normalRangeProperties !== undefined) {
+            if (
+                options.normalRangeProperties.constructor !==
+                NormalRangeProperties
+            ) {
+                throw new Error(
+                    "Option 'normalRangeProperties' must have type NormalRangeProperties."
+                );
+            }
+            this.push(...normalRangeProperties);
+        }
+        if (options.levelOfSignificance !== undefined) {
+            const levelOfSignificanceItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121403",
+                    schemeDesignator: "DCM",
+                    meaning: "Level of Significance"
+                }),
+                value: options.levelOfSignificance,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(levelOfSignificanceItem);
+        }
+        if (options.selectionStatus !== undefined) {
+            const selectionStatusItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121404",
+                    schemeDesignator: "DCM",
+                    meaning: "Selection Status"
+                }),
+                value: options.selectionStatus,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(selectionStatusItem);
+        }
+        if (options.upperMeasurementUncertainty !== undefined) {
+            const upperMeasurementUncertaintyItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "R-00364",
+                    schemeDesignator: "SRT",
+                    meaning: "Range of Upper Measurement Uncertainty"
+                }),
+                value: options.upperMeasurementUncertainty,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(upperMeasurementUncertaintyItem);
+        }
+        if (options.lowerMeasurementUncertainty !== undefined) {
+            const lowerMeasurementUncertaintyItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "R-00362",
+                    schemeDesignator: "SRT",
+                    meaning: "Range of Lower Measurement Uncertainty"
+                }),
+                value: options.lowerMeasurementUncertainty,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(lowerMeasurementUncertaintyItem);
+        }
+    }
+}
+
+class MeasurementStatisticalProperties extends Template {
+    constructor(options) {
+        super();
+        if (options.values === undefined) {
+            throw new Error(
+                "Option 'values' is required for MeasurementStatisticalProperties."
+            );
+        }
+        if (
+            !(
+                typeof options.values === "object" ||
+                options.values instanceof Array
+            )
+        ) {
+            throw new Error("Option 'values' must have type Array.");
+        }
+        options.values.forEach(value => {
+            if (
+                !options.concept ||
+                options.concept.constructor !== NumContentItem
+            ) {
+                throw new Error(
+                    "Items of option 'values' must have type NumContentItem."
+                );
+            }
+            this.push(value);
+        });
+        if (options.description !== undefined) {
+            const descriptionItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121405",
+                    schemeDesignator: "DCM",
+                    meaning: "Population Description"
+                }),
+                value: options.authority,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(authorityItem);
+        }
+        if (options.authority !== undefined) {
+            const authorityItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121406",
+                    schemeDesignator: "DCM",
+                    meaning: "Population Authority"
+                }),
+                value: options.authority,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(authorityItem);
+        }
+    }
+}
+
+class NormalRangeProperties extends Template {
+    constructor(options) {
+        super();
+        if (options.values === undefined) {
+            throw new Error(
+                "Option 'values' is required for NormalRangeProperties."
+            );
+        }
+        if (
+            !(
+                typeof options.values === "object" ||
+                options.values instanceof Array
+            )
+        ) {
+            throw new Error("Option 'values' must have type Array.");
+        }
+        options.values.forEach(value => {
+            if (
+                !options.concept ||
+                options.concept.constructor !== NumContentItem
+            ) {
+                throw new Error(
+                    "Items of option 'values' must have type NumContentItem."
+                );
+            }
+            this.push(value);
+        });
+        if (options.description !== undefined) {
+            const descriptionItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121407",
+                    schemeDesignator: "DCM",
+                    meaning: "Normal Range Description"
+                }),
+                value: options.authority,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(authorityItem);
+        }
+        if (options.authority !== undefined) {
+            const authorityItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121408",
+                    schemeDesignator: "DCM",
+                    meaning: "Normal Range Authority"
+                }),
+                value: options.authority,
+                relationshipType: RelationshipTypes.HAS_PROPERTIES
+            });
+            this.push(authorityItem);
+        }
+    }
+}
+
+class ObservationContext extends Template {
+    constructor(options) {
+        super();
+        if (options.observerPersonContext === undefined) {
+            throw new Error(
+                "Option 'observerPersonContext' is required for ObservationContext."
+            );
+        }
+        if (options.observerPersonContext.constructor !== ObserverContext) {
+            throw new Error(
+                "Option 'observerPersonContext' must have type ObserverContext"
+            );
+        }
+        this.push(...options.observerPersonContext);
+        if (options.observerDeviceContext !== undefined) {
+            if (options.observerDeviceContext.constructor !== ObserverContext) {
+                throw new Error(
+                    "Option 'observerDeviceContext' must have type ObserverContext"
+                );
+            }
+            this.push(...options.observerDeviceContext);
+        }
+        if (options.subjectContext !== undefined) {
+            if (options.subjectContext.constructor !== SubjectContext) {
+                throw new Error(
+                    "Option 'subjectContext' must have type SubjectContext"
+                );
+            }
+            this.push(...options.subjectContext);
+        }
+    }
+}
+
+class ObserverContext extends Template {
+    constructor(options) {
+        super();
+        if (options.observerType === undefined) {
+            throw new Error(
+                "Option 'observerType' is required for ObserverContext."
+            );
+        } else {
+            if (
+                options.observerType.constructor !== Code &&
+                options.observerType.constructor !== CodedConcept
+            ) {
+                throw new Error(
+                    "Option 'observerType' must have type Code or CodedConcept."
+                );
+            }
+        }
+        const observerTypeItem = new CodeContentItem({
+            name: new CodedConcept({
+                value: "121005",
+                meaning: "Observer Type",
+                schemeDesignator: "DCM"
+            }),
+            value: options.observerType,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(observerTypeItem);
+        if (options.observerIdentifyingAttributes === undefined) {
+            throw new Error(
+                "Option 'observerIdentifyingAttributes' is required for ObserverContext."
+            );
+        }
+        // FIXME
+        const person = new CodedConcept({
+            value: "121006",
+            schemeDesignator: "DCM",
+            meaning: "Person"
+        });
+        const device = new CodedConcept({
+            value: "121007",
+            schemeDesignator: "DCM",
+            meaning: "Device"
+        });
+        if (person.equals(options.observerType)) {
+            if (
+                options.observerIdentifyingAttributes.constructor !==
+                PersonObserverIdentifyingAttributes
+            ) {
+                throw new Error(
+                    "Option 'observerIdentifyingAttributes' must have type " +
+                        "PersonObserverIdentifyingAttributes for 'Person' observer type."
+                );
+            }
+        } else if (device.equals(options.observerType)) {
+            if (
+                options.observerIdentifyingAttributes.constructor !==
+                DeviceObserverIdentifyingAttributes
+            ) {
+                throw new Error(
+                    "Option 'observerIdentifyingAttributes' must have type " +
+                        "DeviceObserverIdentifyingAttributes for 'Device' observer type."
+                );
+            }
+        } else {
+            throw new Error(
+                "Option 'oberverType' must be either 'Person' or 'Device'."
+            );
+        }
+        this.push(...options.observerIdentifyingAttributes);
+    }
+}
+
+class PersonObserverIdentifyingAttributes extends Template {
+    constructor(options) {
+        super();
+        if (options.name === undefined) {
+            throw new Error(
+                "Option 'name' is required for PersonObserverIdentifyingAttributes."
+            );
+        }
+        const nameItem = new PNameContentItem({
+            name: new CodedConcept({
+                value: "121008",
+                meaning: "Person Observer Name",
+                schemeDesignator: "DCM"
+            }),
+            value: options.name,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(nameItem);
+        if (options.loginName !== undefined) {
+            const loginNameItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "128774",
+                    meaning: "Person Observer's Login Name",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.loginName,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(loginNameItem);
+        }
+        if (options.organizationName !== undefined) {
+            const organizationNameItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121009",
+                    meaning: "Person Observer's Organization Name",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.organizationName,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(organizationNameItem);
+        }
+        if (options.roleInOrganization !== undefined) {
+            const roleInOrganizationItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121010",
+                    meaning: "Person Observer's Role in the Organization",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.roleInOrganization,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(roleInOrganizationItem);
+        }
+        if (options.roleInProcedure !== undefined) {
+            const roleInProcedureItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121011",
+                    meaning: "Person Observer's Role in this Procedure",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.roleInProcedure,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(roleInProcedureItem);
+        }
+    }
+}
+
+class DeviceObserverIdentifyingAttributes extends Template {
+    constructor(options) {
+        super();
+        if (options.uid === undefined) {
+            throw new Error(
+                "Option 'uid' is required for DeviceObserverIdentifyingAttributes."
+            );
+        }
+        const deviceObserverItem = new UIDRefContentItem({
+            name: new CodedConcept({
+                value: "121012",
+                meaning: "Device Observer UID",
+                schemeDesignator: "DCM"
+            }),
+            value: options.uid,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(deviceObserverItem);
+        if (options.manufacturerName !== undefined) {
+            const manufacturerNameItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121013",
+                    meaning: "Device Observer Manufacturer",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.manufacturerName,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(manufacturerNameItem);
+        }
+        if (options.modelName !== undefined) {
+            const modelNameItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121015",
+                    meaning: "Device Observer Model Name",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.modelName,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(modelNameItem);
+        }
+        if (options.serialNumber !== undefined) {
+            const serialNumberItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121016",
+                    meaning: "Device Observer Serial Number",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.serialNumber,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(serialNumberItem);
+        }
+        if (options.physicalLocation !== undefined) {
+            const physicalLocationItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121017",
+                    meaning:
+                        "Device Observer Physical Location During Observation",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.physicalLocation,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(physicalLocationItem);
+        }
+        if (options.roleInProcedure !== undefined) {
+            const roleInProcedureItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "113876",
+                    meaning: "Device Role in Procedure",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.roleInProcedure,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(roleInProcedureItem);
+        }
+    }
+}
+
+class SubjectContext extends Template {
+    constructor(options) {
+        super();
+        if (options.subjectClass === undefined) {
+            throw new Error(
+                "Option 'subjectClass' is required for SubjectContext."
+            );
+        }
+        if (options.subjectClassSpecificContext === undefined) {
+            throw new Error(
+                "Option 'subjectClassSpecificContext' is required for SubjectContext."
+            );
+        }
+        const subjectClassItem = new CodeContentItem({
+            name: new CodedConcept({
+                value: "121024",
+                meaning: "Subject Class",
+                schemeDesignator: "DCM"
+            }),
+            value: options.subjectClass,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(subjectClassItem);
+        const fetus = new CodedConcept({
+            value: "121026 ",
+            schemeDesignator: "DCM",
+            meaning: "Fetus"
+        });
+        const specimen = new CodedConcept({
+            value: "121027",
+            schemeDesignator: "DCM",
+            meaning: "Specimen"
+        });
+        const device = new CodedConcept({
+            value: "121192",
+            schemeDesignator: "DCM",
+            meaning: "Device Subject"
+        });
+        if (fetus.equals(options.subjectClass)) {
+            if (
+                options.subjectClassSpecificContext.constructor !==
+                SubjectContextFetus
+            ) {
+                throw new Error(
+                    "Option 'subjectClass' must have type " +
+                        "SubjectContextFetus for 'Fetus' subject class."
+                );
+            }
+        } else if (specimen.equals(options.subjectClass)) {
+            if (
+                options.subjectClassSpecificContext.constructor !==
+                SubjectContextSpecimen
+            ) {
+                throw new Error(
+                    "Option 'subjectClass' must have type " +
+                        "SubjectContextSpecimen for 'Specimen' subject class."
+                );
+            }
+        } else if (device.equals(options.subjectClass)) {
+            if (
+                options.subjectClassSpecificContext.constructor !==
+                SubjectContextDevice
+            ) {
+                throw new Error(
+                    "Option 'subjectClass' must have type " +
+                        "SubjectContextDevice for 'Device' subject class."
+                );
+            }
+        } else {
+            throw new Error(
+                "Option 'subjectClass' must be either 'Fetus', 'Specimen', or 'Device'."
+            );
+        }
+        this.push(...options.subjectClassSpecificContext);
+    }
+}
+
+class SubjectContextFetus extends Template {
+    constructor(options) {
+        super();
+        if (options.subjectID === undefined) {
+            throw new Error(
+                "Option 'subjectID' is required for SubjectContextFetus."
+            );
+        }
+        const subjectIdItem = new TextContentItem({
+            name: new CodedConcept({
+                value: "121030",
+                meaning: "Subject ID",
+                schemeDesignator: "DCM"
+            }),
+            value: options.subjectID,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(subjectIdItem);
+    }
+}
+
+class SubjectContextSpecimen extends Template {
+    constructor(options) {
+        super();
+        if (options.uid === undefined) {
+            throw new Error(
+                "Option 'uid' is required for SubjectContextSpecimen."
+            );
+        }
+        const specimenUidItem = new UIDRefContentItem({
+            name: new CodedConcept({
+                value: "121039",
+                meaning: "Specimen UID",
+                schemeDesignator: "DCM"
+            }),
+            value: options.uid,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(specimenUidItem);
+        if (options.identifier !== undefined) {
+            const specimenIdentifierItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121041",
+                    meaning: "Specimen Identifier",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.identifier,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(specimenIdentifierItem);
+        }
+        if (options.containerIdentifier !== undefined) {
+            const containerIdentifierItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "111700",
+                    meaning: "Specimen Container Identifier",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.containerIdentifier,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(containerIdentifierItem);
+        }
+        if (options.specimenType !== undefined) {
+            const specimenTypeItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "R-00254",
+                    meaning: "Specimen Type",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.specimenType,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(specimenTypeItem);
+        }
+    }
+}
+
+class SubjectContextDevice extends Template {
+    constructor(options) {
+        if (options.name === undefined) {
+            throw new Error(
+                "Option 'name' is required for SubjectContextDevice."
+            );
+        }
+        const deviceNameItem = new TextContentItem({
+            name: new CodedConcept({
+                value: "121193",
+                meaning: "Device Subject Name",
+                schemeDesignator: "DCM"
+            }),
+            value: options.name,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(deviceNameItem);
+        if (options.uid !== undefined) {
+            const deviceUidItem = new UIDRefContentItem({
+                name: new CodedConcept({
+                    value: "121198",
+                    meaning: "Device Subject UID",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.uid,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(deviceUidItem);
+        }
+        if (options.manufacturerName !== undefined) {
+            const manufacturerNameItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121194",
+                    meaning: "Device Subject Manufacturer",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.manufacturerName,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(manufacturerNameItem);
+        }
+        if (options.modelName !== undefined) {
+            const modelNameItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121195",
+                    meaning: "Device Subject Model Name",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.modelName,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(modelNameItem);
+        }
+        if (options.serialNumber !== undefined) {
+            const serialNumberItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121196",
+                    meaning: "Device Subject Serial Number",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.serialNumber,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(serialNumberItem);
+        }
+        if (options.physicalLocation !== undefined) {
+            const physicalLocationItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "121197",
+                    meaning:
+                        "Device Subject Physical Location During Observation",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.physicalLocation,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(physicalLocationItem);
+        }
+    }
+}
+
+class LanguageOfContentItemAndDescendants extends Template {
+    constructor(options) {
+        super();
+        if (options.language === undefined) {
+            options.language = new CodedConcept({
+                value: "en-US",
+                schemeDesignator: "RFC5646",
+                meaning: "English (United States)"
+            });
+        }
+        const languageItem = new CodeContentItem({
+            name: new CodedConcept({
+                value: "121049",
+                meaning: "Language of Content Item and Descendants",
+                schemeDesignator: "DCM"
+            }),
+            value: options.language,
+            relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+        });
+        this.push(languageItem);
+    }
+}
+
+class _MeasurementsAndQualitatitiveEvaluations extends Template {
+    constructor(options) {
+        super();
+        const groupItem = new ContainerContentItem({
+            name: new CodedConcept({
+                value: "125007",
+                meaning: "Measurement Group",
+                schemeDesignator: "DCM"
+            }),
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+        groupItem.ContentSequence = new ContentSequence();
+        if (options.trackingIdentifier === undefined) {
+            throw new Error(
+                "Option 'trackingIdentifier' is required for measurements group."
+            );
+        }
+        if (options.trackingIdentifier.constructor !== TrackingIdentifier) {
+            throw new Error(
+                "Option 'trackingIdentifier' must have type TrackingIdentifier."
+            );
+        }
+        if (options.trackingIdentifier.length !== 2) {
+            throw new Error(
+                "Option 'trackingIdentifier' must include a human readable tracking " +
+                    "identifier and a tracking unique identifier."
+            );
+        }
+        groupItem.ContentSequence.push(...options.trackingIdentifier);
+        if (options.session !== undefined) {
+            const sessionItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "C67447",
+                    meaning: "Activity Session",
+                    schemeDesignator: "NCIt"
+                }),
+                value: options.session,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            groupItem.ContentSequence.push(sessionItem);
+        }
+        if (options.findingType !== undefined) {
+            const findingTypeItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121071",
+                    meaning: "Finding",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.findingType,
+                relationshipType: RelationshipTypes.CONTAINS
+            });
+            groupItem.ContentSequence.push(findingTypeItem);
+        }
+        if (options.timePointContext !== undefined) {
+            if (options.timePointContext.constructor !== TimePointContext) {
+                throw new Error(
+                    "Option 'timePointContext' must have type TimePointContext."
+                );
+            }
+            groupItem.ContentSequence.push(...timePointContext);
+        }
+        if (options.referencedRealWorldValueMap !== undefined) {
+            if (
+                options.referencedRealWorldValueMap.constructor !==
+                ReferencedRealWorldValueMap
+            ) {
+                throw new Error(
+                    "Option 'referencedRealWorldValleMap' must have type " +
+                        "ReferencedRealWorldValueMap."
+                );
+            }
+            groupItem.ContentSequence.push(options.referencedRealWorldValueMap);
+        }
+        if (options.measurements !== undefined) {
+            if (
+                !(
+                    typeof options.measurements === "object" ||
+                    options.measurements instanceof Array
+                )
+            ) {
+                throw new Error("Option 'measurements' must have type Array.");
+            }
+            options.measurements.forEach(measurement => {
+                console.log(measurement);
+                if (
+                    !measurement ||
+                    measurement.constructor !== NumContentItem
+                ) {
+                    throw new Error(
+                        "Items of option 'measurement' must have type NumContentItem."
+                    );
+                }
+                groupItem.ContentSequence.push(measurement);
+            });
+        }
+        if (options.qualitativeEvaluations !== undefined) {
+            if (
+                !(
+                    typeof options.qualitativeEvaluations === "object" ||
+                    options.qualitativeEvaluations instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'qualitativeEvaluations' must have type Array."
+                );
+            }
+            options.qualitativeEvaluations.forEach(evaluation => {
+                if (!evaluation || evaluation.constructor !== CodeContentItem) {
+                    throw new Error(
+                        "Items of option 'qualitativeEvaluations' must have type " +
+                            "CodeContentItem."
+                    );
+                }
+                groupItem.ContentSequence.push(evaluation);
+            });
+        }
+        this.push(groupItem);
+    }
+}
+
+class _ROIMeasurementsAndQualitativeEvaluations extends _MeasurementsAndQualitatitiveEvaluations {
+    constructor(options) {
+        super({
+            trackingIdentifier: options.trackingIdentifier,
+            timePointContext: options.timePointContext,
+            findingType: options.findingType,
+            session: options.session,
+            measurements: options.measurements,
+            qualitativeEvaluations: options.qualitativeEvaluations
+        });
+        const groupItem = this[0];
+        const wereReferencesProvided = [
+            options.referencedRegions !== undefined,
+            options.referencedVolume !== undefined,
+            options.referencedSegmentation !== undefined
+        ];
+        const numReferences = wereReferencesProvided.reduce((a, b) => a + b);
+        if (numReferences === 0) {
+            throw new Error(
+                "One of the following options must be provided: " +
+                    "'referencedRegions', 'referencedVolume', or " +
+                    "'referencedSegmentation'."
+            );
+        } else if (numReferences > 1) {
+            throw new Error(
+                "Only one of the following options should be provided: " +
+                    "'referencedRegions', 'referencedVolume', or " +
+                    "'referencedSegmentation'."
+            );
+        }
+        if (options.referencedRegions !== undefined) {
+            if (
+                !(
+                    typeof options.referencedRegions === "object" ||
+                    options.referencedRegions instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedRegions' must have type Array."
+                );
+            }
+            if (options.referencedRegions.length === 0) {
+                throw new Error(
+                    "Option 'referencedRegion' must have non-zero length."
+                );
+            }
+            options.referencedRegions.forEach(region => {
+                if (
+                    region === undefined ||
+                    (region.constructor !== ImageRegion &&
+                        region.constructor !== ImageRegion3D)
+                ) {
+                    throw new Error(
+                        "Items of option 'referencedRegion' must have type " +
+                            "ImageRegion or ImageRegion3D."
+                    );
+                }
+                groupItem.ContentSequence.push(region);
+            });
+        } else if (options.referencedVolume !== undefined) {
+            if (options.referencedVolume.constructor !== VolumeSurface) {
+                throw new Error(
+                    "Items of option 'referencedVolume' must have type VolumeSurface."
+                );
+            }
+            groupItem.ContentSequence.push(referencedVolume);
+        } else if (options.referencedSegmentation !== undefined) {
+            if (
+                options.referencedSegmentation.constructor !==
+                    ReferencedSegmentation &&
+                options.referencedSegmentation.constructor !==
+                    ReferencedSegmentationFrame
+            ) {
+                throw new Error(
+                    "Option 'referencedSegmentation' must have type " +
+                        "ReferencedSegmentation or ReferencedSegmentationFrame."
+                );
+            }
+            groupItem.ContentSequence.push(referencedSegmentation);
+        }
+        this[0] = groupItem;
+    }
+}
+
+class PlanarROIMeasurementsAndQualitativeEvaluations extends _ROIMeasurementsAndQualitativeEvaluations {
+    constructor(options) {
+        const wereReferencesProvided = [
+            options.referencedRegion !== undefined,
+            options.referencedSegmentation !== undefined
+        ];
+        const numReferences = wereReferencesProvided.reduce((a, b) => a + b);
+        if (numReferences === 0) {
+            throw new Error(
+                "One of the following options must be provided: " +
+                    "'referencedRegion', 'referencedSegmentation'."
+            );
+        } else if (numReferences > 1) {
+            throw new Error(
+                "Only one of the following options should be provided: " +
+                    "'referencedRegion', 'referencedSegmentation'."
+            );
+        }
+        super({
+            trackingIdentifier: options.trackingIdentifier,
+            referencedRegions: [options.referencedRegion],
+            referencedSegmentation: options.referencedSegmentation,
+            referencedRealWorldValueMap: options.referencedRealWorldValueMap,
+            timePointContext: options.timePointContext,
+            findingType: options.findingType,
+            session: options.session,
+            measurements: options.measurements,
+            qualitativeEvaluations: options.qualitativeEvaluations
+        });
+    }
+}
+
+class VolumetricROIMeasurementsAndQualitativeEvaluations extends _ROIMeasurementsAndQualitativeEvaluations {
+    constructor(options) {
+        super({
+            trackingIdentifier: options.trackingIdentifier,
+            referencedRegions: options.referencedRegions,
+            referencedSegmentation: options.referencedSegmentation,
+            referencedRealWorldValueMap: options.referencedRealWorldValueMap,
+            timePointContext: options.timePointContext,
+            findingType: options.findingType,
+            session: options.session,
+            measurements: options.measurements,
+            qualitativeEvaluations: options.qualitativeEvaluations
+        });
+    }
+}
+
+class MeasurementsDerivedFromMultipleROIMeasurements extends Template {
+    constructor(options) {
+        if (options.derivation === undefined) {
+            throw new Error(
+                "Option 'derivation' is required for " +
+                    "MeasurementsDerivedFromMultipleROIMeasurements."
+            );
+        }
+        // FIXME
+        const valueItem = new NumContentItem({
+            name: options.derivation
+        });
+        valueItem.ContentSequence = new ContentSequence();
+        if (options.measurementGroups === undefined) {
+            throw new Error(
+                "Option 'measurementGroups' is required for " +
+                    "MeasurementsDerivedFromMultipleROIMeasurements."
+            );
+        }
+        if (
+            !(
+                typeof options.measurementGroups === "object" ||
+                options.measurementGroups instanceof Array
+            )
+        ) {
+            throw new Error("Option 'measurementGroups' must have type Array.");
+        }
+        options.measurementGroups.forEach(group => {
+            if (
+                !group ||
+                (group.constructor !==
+                    PlanarROIMeasurementsAndQualitativeEvaluations &&
+                    group.constructor !==
+                        VolumetricROIMeasurementsAndQualitativeEvaluations)
+            ) {
+                throw new Error(
+                    "Items of option 'measurementGroups' must have type " +
+                        "PlanarROIMeasurementsAndQualitativeEvaluations or " +
+                        "VolumetricROIMeasurementsAndQualitativeEvaluations."
+                );
+            }
+            group[0].RelationshipType = "R-INFERRED FROM";
+            valueItem.ContentSequence.push(...group);
+        });
+        if (options.measurementProperties !== undefined) {
+            if (
+                options.measurementProperties.constructor !==
+                MeasurementProperties
+            ) {
+                throw new Error(
+                    "Option 'measurementProperties' must have type MeasurementProperties."
+                );
+            }
+            valueItem.ContentSequence.push(...options.measurementProperties);
+        }
+        this.push(valueItem);
+    }
+}
+
+class MeasurementAndQualitativeEvaluationGroup extends _MeasurementsAndQualitatitiveEvaluations {
+    constructor(options) {
+        super({
+            trackingIdentifier: options.trackingIdentifier,
+            referencedRealWorldValueMap: options.referencedRealWorldValueMap,
+            timePointContext: options.timePointContext,
+            findingType: options.findingType,
+            session: options.session,
+            measurements: options.measurements,
+            qualitativeEvaluations: options.qualitativeEvaluations
+        });
+    }
+}
+
+class ROIMeasurements extends Template {
+    constructor(options) {
+        super();
+        if (options.method !== undefined) {
+            const methodItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "370129005",
+                    meaning: "Measurement Method",
+                    schemeDesignator: "SCT"
+                }),
+                value: options.method,
+                relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+            });
+            this.push(methodItem);
+        }
+        if (options.findingSites !== undefined) {
+            if (
+                !(
+                    typeof options.findingSites === "object" ||
+                    options.findingSites instanceof Array
+                )
+            ) {
+                throw new Error("Option 'findingSites' must have type Array.");
+            }
+            options.findingSites.forEach(site => {
+                if (!site || site.constructor !== FindingSite) {
+                    throw new Error(
+                        "Items of option 'findingSites' must have type FindingSite."
+                    );
+                }
+                this.push(site);
+            });
+        }
+        if (options.measurements === undefined) {
+            throw new Error(
+                "Options 'measurements' is required ROIMeasurements."
+            );
+        }
+        if (
+            !(
+                typeof options.measurements === "object" ||
+                options.measurements instanceof Array
+            )
+        ) {
+            throw new Error("Option 'measurements' must have type Array.");
+        }
+        if (options.measurements.length === 0) {
+            throw new Error("Option 'measurements' must have non-zero length.");
+        }
+        options.measurements.forEach(measurement => {
+            if (!measurement || measurement.constructor !== Measurement) {
+                throw new Error(
+                    "Items of option 'measurements' must have type Measurement."
+                );
+            }
+            this.push(measurement);
+        });
+    }
+}
+
+class MeasurementReport extends Template {
+    constructor(options) {
+        super();
+        if (options.observationContext === undefined) {
+            throw new Error(
+                "Option 'observationContext' is required for MeasurementReport."
+            );
+        }
+        if (options.procedureReported === undefined) {
+            throw new Error(
+                "Option 'procedureReported' is required for MeasurementReport."
+            );
+        }
+        const item = new ContainerContentItem({
+            name: new CodedConcept({
+                value: "126000",
+                schemeDesignator: "DCM",
+                meaning: "Imaging Measurement Report"
+            }),
+            templateID: "1500"
+        });
+        item.ContentSequence = new ContentSequence();
+        if (options.languageOfContentItemAndDescendants === undefined) {
+            throw new Error(
+                "Option 'languageOfContentItemAndDescendants' is required for " +
+                    "MeasurementReport."
+            );
+        }
+        if (
+            options.languageOfContentItemAndDescendants.constructor !==
+            LanguageOfContentItemAndDescendants
+        ) {
+            throw new Error(
+                "Option 'languageOfContentItemAndDescendants' must have type " +
+                    "LanguageOfContentItemAndDescendants."
+            );
+        }
+        item.ContentSequence.push(
+            ...options.languageOfContentItemAndDescendants
+        );
+        item.ContentSequence.push(...options.observationContext);
+        if (
+            options.procedureReported.constructor === CodedConcept ||
+            options.procedureReported.constructor === Code
+        ) {
+            options.procedureReported = [options.procedureReported];
+        }
+        if (
+            !(
+                typeof options.procedureReported === "object" ||
+                options.procedureReported instanceof Array
+            )
+        ) {
+            throw new Error("Option 'procedureReported' must have type Array.");
+        }
+        options.procedureReported.forEach(procedure => {
+            const procedureItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "121058",
+                    meaning: "Procedure reported",
+                    schemeDesignator: "DCM"
+                }),
+                value: procedure,
+                relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+            });
+            item.ContentSequence.push(procedureItem);
+        });
+        const imageLibraryItem = new ImageLibrary();
+        item.ContentSequence.push(...imageLibraryItem);
+
+        const wereOptionsProvided = [
+            options.imagingMeasurements !== undefined,
+            options.derivedImagingMeasurements !== undefined,
+            options.qualitativeEvaluations !== undefined
+        ];
+        const numOptionsProvided = wereOptionsProvided.reduce((a, b) => a + b);
+        if (numOptionsProvided > 1) {
+            throw new Error(
+                "Only one of the following options should be provided: " +
+                    "'imagingMeasurements', 'derivedImagingMeasurement', " +
+                    "'qualitativeEvaluations'."
+            );
+        }
+        if (options.imagingMeasurements !== undefined) {
+            const containerItem = new ContainerContentItem({
+                name: new CodedConcept({
+                    value: "126010",
+                    meaning: "Imaging Measurements",
+                    schemeDesignator: "DCM"
+                }),
+                relationshipType: RelationshipTypes.CONTAINS
+            });
+            containerItem.ContentSequence = new ContentSequence(
+                ...options.imagingMeasurements
+            );
+            item.ContentSequence.push(containerItem);
+        } else if (options.derivedImagingMeasurements !== undefined) {
+            const containerItem = new ContainerContentItem({
+                name: new CodedConcept({
+                    value: "126011",
+                    meaning: "Derived Imaging Measurements",
+                    schemeDesignator: "DCM"
+                }),
+                relationshipType: RelationshipTypes.CONTAINS
+            });
+            containerItem.ContentSequence = new ContentSequence(
+                ...options.derivedImagingMeasurements
+            );
+            item.ContentSequence.push(containerItem);
+        } else if (options.qualitativeEvaluations !== undefined) {
+            const containerItem = new ContainerContentItem({
+                name: new CodedConcept({
+                    value: "C0034375",
+                    meaning: "Qualitative Evaluations",
+                    schemeDesignator: "UMLS"
+                }),
+                relationshipType: RelationshipTypes.CONTAINS
+            });
+            containerItem.ContentSequence = new ContentSequence(
+                ...options.qualitativeEvaluations
+            );
+            item.ContentSequence.push(containerItem);
+        }
+        this.push(item);
+    }
+}
+
+class TimePointContext extends Template {
+    constructor(options) {
+        if (options.timePoint === undefined) {
+            throw new Error(
+                "Option 'timePoint' is required for TimePointContext."
+            );
+        }
+        const timePointItem = new TextContentItem({
+            name: new CodedConcept({
+                value: "C2348792",
+                meaning: "Time Point",
+                schemeDesignator: "UMLS"
+            }),
+            value: options.timePoint,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(timePointItem);
+        if (options.timePointType !== undefined) {
+            const timePointTypeItem = new CodeContentItem({
+                name: new CodedConcept({
+                    value: "126072",
+                    meaning: "Time Point Type",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.timePointType,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(timePointTypeItem);
+        }
+        if (options.timePointOrder !== undefined) {
+            const timePointOrderItem = new NumContentItem({
+                name: new CodedConcept({
+                    value: "126073",
+                    meaning: "Time Point Order",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.timePointOrder,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(timePointOrderItem);
+        }
+        if (options.subjectTimePointIdentifier !== undefined) {
+            const subjectTimePointIdentifierItem = new NumContentItem({
+                name: new CodedConcept({
+                    value: "126070",
+                    meaning: "Subject Time Point Identifier",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.subjectTimePointIdentifier,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(subjectTimePointIdentifierItem);
+        }
+        if (options.protocolTimePointIdentifier !== undefined) {
+            const protocolTimePointIdentifierItem = new NumContentItem({
+                name: new CodedConcept({
+                    value: "126071",
+                    meaning: "Protocol Time Point Identifier",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.protocolTimePointIdentifier,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(protocolTimePointIdentifierItem);
+        }
+        if (options.temporalOffsetFromEvent !== undefined) {
+            if (
+                options.temporalOffsetFromEvent.constructor !==
+                LongitudinalTemporalOffsetFromEventContentItem
+            ) {
+                throw new Error(
+                    "Option 'temporalOffsetFromEvent' must have type " +
+                        "LongitudinalTemporalOffsetFromEventContentItem."
+                );
+            }
+            this.push(temporalOffsetFromEvent);
+        }
+    }
+}
+
+class ImageLibrary extends Template {
+    constructor(options) {
+        super();
+        const libraryItem = new ContainerContentItem({
+            name: new CodedConcept({
+                value: "111028",
+                meaning: "Image Library",
+                schemeDesignator: "DCM"
+            }),
+            relationshipType: RelationshipTypes.CONTAINS
+        });
+        this.push(libraryItem);
+    }
+}
+
+class AlgorithmIdentification extends Template {
+    constructor(options) {
+        super();
+        if (options.name === undefined) {
+            throw new Error(
+                "Option 'name' is required for AlgorithmIdentification."
+            );
+        }
+        if (options.version === undefined) {
+            throw new Error(
+                "Option 'version' is required for AlgorithmIdentification."
+            );
+        }
+        const nameItem = new TextContentItem({
+            name: new CodedConcept({
+                value: "111001",
+                meaning: "Algorithm Name",
+                schemeDesignator: "DCM"
+            }),
+            value: options.name,
+            relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+        });
+        this.push(nameItem);
+        const versionItem = new TextContentItem({
+            name: new CodedConcept({
+                value: "111003",
+                meaning: "Algorithm Version",
+                schemeDesignator: "DCM"
+            }),
+            value: options.version,
+            relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+        });
+        this.push(versionItem);
+        if (options.parameters !== undefined) {
+            if (
+                !(
+                    typeof options.parameters === "object" ||
+                    options.parameters instanceof Array
+                )
+            ) {
+                throw new Error("Option 'parameters' must have type Array.");
+            }
+            options.parameters.forEach(parameter => {
+                const parameterItem = new TextContentItem({
+                    name: new CodedConcept({
+                        value: "111002",
+                        meaning: "Algorithm Parameter",
+                        schemeDesignator: "DCM"
+                    }),
+                    value: param,
+                    relationshipType: RelationshipTypes.HAS_CONCEPT_MOD
+                });
+                this.push(parameterItem);
+            });
+        }
+    }
+}
+
+class TrackingIdentifier extends Template {
+    constructor(options) {
+        super();
+        if (options.uid === undefined) {
+            throw new Error("Option 'uid' is required for TrackingIdentifier.");
+        }
+        if (options.identifier !== undefined) {
+            const trackingIdentifierItem = new TextContentItem({
+                name: new CodedConcept({
+                    value: "112039",
+                    meaning: "Tracking Identifier",
+                    schemeDesignator: "DCM"
+                }),
+                value: options.identifier,
+                relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+            });
+            this.push(trackingIdentifierItem);
+        }
+        const trackingUIDItem = new UIDRefContentItem({
+            name: new CodedConcept({
+                value: "112040",
+                meaning: "Tracking Unique Identifier",
+                schemeDesignator: "DCM"
+            }),
+            value: options.uid,
+            relationshipType: RelationshipTypes.HAS_OBS_CONTEXT
+        });
+        this.push(trackingUIDItem);
+    }
+}
+
+export {
+    AlgorithmIdentification,
+    DeviceObserverIdentifyingAttributes,
+    ImageLibrary,
+    LanguageOfContentItemAndDescendants,
+    Measurement,
+    MeasurementAndQualitativeEvaluationGroup,
+    MeasurementReport,
+    MeasurementsDerivedFromMultipleROIMeasurements,
+    ObservationContext,
+    ObserverContext,
+    PersonObserverIdentifyingAttributes,
+    PlanarROIMeasurementsAndQualitativeEvaluations,
+    ROIMeasurements,
+    SubjectContext,
+    SubjectContextDevice,
+    SubjectContextFetus,
+    SubjectContextSpecimen,
+    TimePointContext,
+    TrackingIdentifier,
+    VolumetricROIMeasurementsAndQualitativeEvaluations
+    // MeasurementProperties,
+    // MeasurementStatisticalProperties,
+    // NormalRangeProperties,
+    // EquationOrTable,
+    // ImageOrSpatialCoordinates,
+    // WaveformOrTemporalCoordinates,
+    // Quotation,
+};

--- a/src/sr/valueTypes.js
+++ b/src/sr/valueTypes.js
@@ -1,0 +1,739 @@
+import { CodedConcept } from "./coding.js";
+
+const ValueTypes = {
+    CODE: "CODE",
+    COMPOSITE: "COMPOSITE",
+    CONTAINER: "CONTAINER",
+    DATE: "DATE",
+    DATETIME: "DATETIME",
+    IMAGE: "IMAGE",
+    NUM: "NUM",
+    PNAME: "PNAME",
+    SCOORD: "SCOORD",
+    SCOORD3D: "SCOORD3D",
+    TCOORD: "TCOORD",
+    TEXT: "TEXT",
+    TIME: "TIME",
+    UIDREF: "UIDREF",
+    WAVEFORM: "WAVEFORM"
+};
+Object.freeze(ValueTypes);
+
+const GraphicTypes = {
+    CIRCLE: "CIRCLE",
+    ELLIPSE: "ELLIPSE",
+    ELLIPSOID: "ELLIPSOID",
+    MULTIPOINT: "MULTIPOINT",
+    POINT: "POINT",
+    POLYLINE: "POLYLINE"
+};
+Object.freeze(GraphicTypes);
+
+const GraphicTypes3D = {
+    ELLIPSE: "ELLIPSE",
+    ELLIPSOID: "ELLIPSOID",
+    MULTIPOINT: "MULTIPOINT",
+    POINT: "POINT",
+    POLYLINE: "POLYLINE",
+    POLYGON: "POLYGON"
+};
+Object.freeze(GraphicTypes3D);
+
+const TemporalRangeTypes = {
+    BEGIN: "BEGIN",
+    END: "END",
+    MULTIPOINT: "MULTIPOINT",
+    MULTISEGMENT: "MULTISEGMENT",
+    POINT: "POINT",
+    SEGMENT: "SEGMENT"
+};
+Object.freeze(TemporalRangeTypes);
+
+const RelationshipTypes = {
+    CONTAINS: "CONTAINS",
+    HAS_ACQ_CONTENT: "HAS ACQ CONTENT",
+    HAS_CONCEPT_MOD: "HAS CONCEPT MOD",
+    HAS_OBS_CONTEXT: "HAS OBS CONTEXT",
+    HAS_PROPERTIES: "HAS PROPERTIES",
+    INFERRED_FROM: "INFERRED FROM",
+    SELECTED_FROM: "SELECTED FROM"
+};
+Object.freeze(RelationshipTypes);
+
+const PixelOriginInterpretations = {
+    FRAME: "FRAME",
+    VOLUME: "VOLUME"
+};
+Object.freeze(RelationshipTypes);
+
+function isFloat(n) {
+    return n === +n && n !== (n | 0);
+}
+
+function isInteger(n) {
+    return n === +n && n === (n | 0);
+}
+
+function zeroPad(value) {
+    return (value > 9 ? "" : "0") + value;
+}
+
+function TM(date) {
+    // %H%M%S.%f
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    const seconds = date.getSeconds();
+    const milliseconds = date.getMilliseconds();
+    return zeroPad(hours) + zeroPad(minutes) + zeroPad(seconds) + milliseconds;
+}
+
+function DA(date) {
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return year + zeroPad(month) + zeroPad(day);
+}
+
+function DT(date) {
+    return DA(date) + TM(date);
+}
+
+class ContentSequence extends Array {
+    constructor(...args) {
+        super(...args);
+    }
+
+    // filterBy(options) {
+    // }
+}
+
+class ContentItem {
+    constructor(options) {
+        if (options.name === undefined) {
+            throw new Error("Option 'name' is required for ContentItem.");
+        }
+        if (options.name.constructor !== CodedConcept) {
+            throw new Error("Option 'name' must have type CodedConcept.");
+        }
+        this.ConceptNameCodeSequence = [options.name];
+        if (options.valueType === undefined) {
+            throw new Error("Option 'valueType' is required for ContentItem.");
+        }
+        if (!(Object.values(ValueTypes).indexOf(options.valueType) !== -1)) {
+            throw new Error(`Invalid value type ${options.valueType}`);
+        }
+        this.ValueType = options.valueType;
+        if (options.relationshipType !== undefined) {
+            if (
+                !(
+                    Object.values(RelationshipTypes).indexOf(
+                        options.relationshipType
+                    ) !== -1
+                )
+            ) {
+                throw new Error(
+                    `Invalid relationship type ${options.relationshipTypes}`
+                );
+            }
+            this.RelationshipType = options.relationshipType;
+        }
+        // TODO: relationship type is required
+    }
+
+    // getContentItems(options) {
+    //   // TODO: filter by name, value type and relationship type
+    //   return this.ContentSequence;
+    // }
+}
+
+class CodeContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.CODE
+        });
+        if (options.value === undefined) {
+            throw new Error("Option 'value' is required for CodeContentItem.");
+        }
+        if (!(options.value || options.value.constructor === CodedConcept)) {
+            throw new Error("Option 'value' must have type CodedConcept.");
+        }
+        this.ConceptCodeSequence = [options.value];
+    }
+}
+
+class TextContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.TEXT
+        });
+        if (options.value === undefined) {
+            throw new Error("Option 'value' is required for TextContentItem.");
+        }
+        if (
+            !(
+                typeof options.value === "string" ||
+                options.value instanceof String
+            )
+        ) {
+            throw new Error("Option 'value' must have type String.");
+        }
+        this.TextValue = options.value;
+    }
+}
+
+class PNameContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.PNAME
+        });
+        if (options.value === undefined) {
+            throw new Error("Option 'value' is required for PNameContentItem.");
+        }
+        if (
+            !(
+                typeof options.value === "string" ||
+                options.value instanceof String
+            )
+        ) {
+            throw new Error("Option 'value' must have type String.");
+        }
+        this.PersonName = options.value;
+    }
+}
+
+class TimeContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.TIME
+        });
+        if (options.value === undefined) {
+            throw new Error("Option 'value' is required for TimeContentItem.");
+        }
+        if (
+            !(
+                typeof options.value === "object" ||
+                options.value instanceof Date
+            )
+        ) {
+            throw new Error("Option 'value' must have type Date.");
+        }
+        this.Time = TM(options.value);
+    }
+}
+
+class DateContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.DATE
+        });
+        if (options.value === undefined) {
+            throw new Error("Option 'value' is required for DateContentItem.");
+        }
+        if (
+            !(
+                typeof options.value === "object" ||
+                options.value instanceof Date
+            )
+        ) {
+            throw new Error("Option 'value' must have type Date.");
+        }
+        this.Date = DA(options.value);
+    }
+}
+
+class DateTimeContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.DATETIME
+        });
+        if (options.value === undefined) {
+            throw new Error(
+                "Option 'value' is required for DateTimeContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.value === "object" ||
+                options.value instanceof Date
+            )
+        ) {
+            throw new Error("Option 'value' must have type Date.");
+        }
+        this.DateTime = DT(otions.value);
+    }
+}
+
+class UIDRefContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.UIDREF
+        });
+        if (options.value === undefined) {
+            throw new Error(
+                "Option 'value' is required for UIDRefContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.value === "string" ||
+                options.value instanceof String
+            )
+        ) {
+            throw new Error("Option 'value' must have type String.");
+        }
+        this.UID = options.value;
+    }
+}
+
+class NumContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.NUM
+        });
+        if (options.value !== undefined) {
+            if (
+                !(
+                    typeof options.value === "number" ||
+                    options.value instanceof Number
+                )
+            ) {
+                throw new Error("Option 'value' must have type Number.");
+            }
+            if (options.unit === undefined) {
+                throw new Error(
+                    "Option 'unit' is required for NumContentItem with 'value'."
+                );
+            }
+            const item = {};
+            item.NumericValue = options.value;
+            if (isFloat(options.value)) {
+                item.FloatingPointValue = options.value;
+            }
+            item.MeasurementUnitsCodeSequence = options.unit;
+            this.MeasuredValueSequence = [item];
+        } else if (options.qualifier !== undefined) {
+            if (
+                !(
+                    options.qualifier ||
+                    options.qualifier.constructor === CodedConcept
+                )
+            ) {
+                throw new Error(
+                    "Option 'qualifier' must have type CodedConcept."
+                );
+            }
+            this.NumericValueQualifierCodeSequence = [options.qualifier];
+        } else {
+            throw new Error(
+                "Either option 'value' or 'qualifier' is required for NumContentItem."
+            );
+        }
+    }
+}
+
+class ContainerContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.CONTAINER
+        });
+        if (options.isContentContinuous !== undefined) {
+            this.ContinuityOfContent = "CONTINUOUS";
+        } else {
+            this.ContinuityOfContent = "SEPARATE";
+        }
+        if (options.templateID !== undefined) {
+            if (
+                !(
+                    typeof options.templateID === "string" ||
+                    options.templateID instanceof String
+                )
+            ) {
+                throw new Error("Option 'templateID' must have type String.");
+            }
+            const item = {};
+            item.MappingResource = "DCMR";
+            item.TemplateIdentifier = options.templateID;
+            this.ContentTemplateSequence = [item];
+        }
+    }
+}
+
+class CompositeContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.COMPOSITE
+        });
+        if (options.referencedSOPClassUID === undefined) {
+            throw new Error(
+                "Option 'referencedSOPClassUID' is required for CompositeContentItem."
+            );
+        }
+        if (options.referencedSOPInstanceUID === undefined) {
+            throw new Error(
+                "Option 'referencedSOPInstanceUID' is required for CompositeContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.referencedSOPClassUID === "string" ||
+                options.referencedSOPClassUID instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'referencedSOPClassUID' must have type String."
+            );
+        }
+        if (
+            !(
+                typeof options.referencedSOPInstanceUID === "string" ||
+                options.referencedSOPInstanceUID instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'referencedSOPInstanceUID' must have type String."
+            );
+        }
+        const item = {};
+        item.ReferencedSOPClassUID = options.referencedSOPClassUID;
+        item.ReferencedSOPInstanceUID = options.referencedSOPInstanceUID;
+        this.ReferenceSOPSequence = [item];
+    }
+}
+
+class ImageContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.IMAGE
+        });
+        if (options.referencedSOPClassUID === undefined) {
+            throw new Error(
+                "Option 'referencedSOPClassUID' is required for ImageContentItem."
+            );
+        }
+        if (options.referencedSOPInstanceUID === undefined) {
+            throw new Error(
+                "Option 'referencedSOPInstanceUID' is required for ImageContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.referencedSOPClassUID === "string" ||
+                options.referencedSOPClassUID instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'referencedSOPClassUID' must have type String."
+            );
+        }
+        if (
+            !(
+                typeof options.referencedSOPInstanceUID === "string" ||
+                options.referencedSOPInstanceUID instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'referencedSOPInstanceUID' must have type String."
+            );
+        }
+        const item = {};
+        item.ReferencedSOPClassUID = options.referencedSOPClassUID;
+        item.ReferencedSOPInstanceUID = options.referencedSOPInstanceUID;
+        if (options.referencedFrameNumbers !== undefined) {
+            if (
+                !(
+                    typeof options.referencedFrameNumbers === "object" ||
+                    options.referencedFrameNumbers instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedFrameNumbers' must have type Array."
+                );
+            }
+            // FIXME: value multiplicity
+            item.ReferencedFrameNumber = options.referencedFrameNumbers;
+        }
+        if (options.referencedFrameSegmentNumber !== undefined) {
+            if (
+                !(
+                    typeof options.referencedSegmentNumbers === "object" ||
+                    options.referencedSegmentNumbers instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedSegmentNumbers' must have type Array."
+                );
+            }
+            // FIXME: value multiplicity
+            item.ReferencedSegmentNumber = options.referencedSegmentNumbers;
+        }
+        this.ReferencedSOPSequence = [item];
+    }
+}
+
+class ScoordContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.SCOORD
+        });
+        if (options.graphicType === undefined) {
+            throw new Error(
+                "Option 'graphicType' is required for ScoordContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.graphicType === "string" ||
+                options.graphicType instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'graphicType' of ScoordContentItem must have type String."
+            );
+        }
+        if (options.graphicData === undefined) {
+            throw new Error(
+                "Option 'graphicData' is required for ScoordContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.graphicData === "object" ||
+                options.graphicData instanceof Array
+            )
+        ) {
+            throw new Error(
+                "Option 'graphicData' of ScoordContentItem must have type Array."
+            );
+        }
+        if (Object.values(GraphicTypes).indexOf(options.graphicType) === -1) {
+            throw new Error(`Invalid graphic type '${options.graphicType}'.`);
+        }
+        if (options.graphicData[0] instanceof Array) {
+            options.graphicData = [].concat.apply([], options.graphicData);
+        }
+        this.GraphicData = options.graphicData;
+        options.pixelOriginInterpretation =
+            options.pixelOriginInterpretation ||
+            PixelOriginInterpretations.VOLUME;
+        if (
+            !(
+                typeof options.pixelOriginInterpretation === "string" ||
+                options.pixelOriginInterpretation instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'pixelOriginInterpretation' must have type String."
+            );
+        }
+        if (
+            Object.values(PixelOriginInterpretations).indexOf(
+                options.pixelOriginInterpretation
+            ) === -1
+        ) {
+            throw new Error(
+                `Invalid pixel origin interpretation '${
+                    options.pixelOriginInterpretation
+                }'.`
+            );
+        }
+        if (options.fiducialUID !== undefined) {
+            if (
+                !(
+                    typeof options.fiducialUID === "string" ||
+                    options.fiducialUID instanceof String
+                )
+            ) {
+                throw new Error("Option 'fiducialUID' must have type String.");
+            }
+            this.FiducialUID = options.fiducialUID;
+        }
+    }
+}
+
+class Scoord3DContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.SCOORD3D
+        });
+        if (options.graphicType === undefined) {
+            throw new Error(
+                "Option 'graphicType' is required for Scoord3DContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.graphicType === "string" ||
+                options.graphicType instanceof String
+            )
+        ) {
+            throw new Error("Option 'graphicType' must have type String.");
+        }
+        if (options.graphicData === undefined) {
+            throw new Error(
+                "Option 'graphicData' is required for Scoord3DContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.graphicData === "object" ||
+                options.graphicData instanceof Array
+            )
+        ) {
+            throw new Error("Option 'graphicData' must have type Array.");
+        }
+        if (Object.values(GraphicTypes3D).indexOf(options.graphicType) === -1) {
+            throw new Error(`Invalid graphic type '${options.graphicType}'.`);
+        }
+        if (options.graphicData[0] instanceof Array) {
+            options.graphicData = [].concat.apply([], options.graphicData);
+        }
+        this.GraphicType = options.graphicType;
+        this.GraphicData = options.graphicData;
+        if (options.frameOfReferenceUID === undefined) {
+            throw new Error(
+                "Option 'frameOfReferenceUID' is required for Scoord3DContentItem."
+            );
+        }
+        if (
+            !(
+                typeof options.frameOfReferenceUID === "string" ||
+                options.frameOfReferenceUID instanceof String
+            )
+        ) {
+            throw new Error(
+                "Option 'frameOfReferenceUID' must have type String."
+            );
+        }
+        this.ReferencedFrameOfReferenceUID = options.frameOfReferenceUID;
+        if ("fiducialUID" in options) {
+            if (
+                !(
+                    typeof options.fiducialUID === "string" ||
+                    options.fiducialUID instanceof String
+                )
+            ) {
+                throw new Error("Option 'fiducialUID' must have type String.");
+            }
+            this.FiducialUID = fiducialUID;
+        }
+    }
+}
+
+class TcoordContentItem extends ContentItem {
+    constructor(options) {
+        super({
+            name: options.name,
+            relationshipType: options.relationshipType,
+            valueType: ValueTypes.TCOORD
+        });
+        if (options.temporalRangeType === undefined) {
+            throw new Error(
+                "Option 'temporalRangeType' is required for TcoordContentItem."
+            );
+        }
+        if (
+            Object.values(TemporalRangeTypes).indexOf(
+                options.temporalRangeType
+            ) === -1
+        ) {
+            throw new Error(
+                `Invalid temporal range type '${options.temporalRangeType}'.`
+            );
+        }
+        if (options.referencedSamplePositions === undefined) {
+            if (
+                !(
+                    typeof options.referencedSamplePositions === "object" ||
+                    options.referencedSamplePositions instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedSamplePositions' must have type Array."
+                );
+            }
+            // TODO: ensure values are integers
+            this.ReferencedSamplePositions = options.referencedSamplePositions;
+        } else if (options.referencedTimeOffsets === undefined) {
+            if (
+                !(
+                    typeof options.referencedTimeOffsets === "object" ||
+                    options.referencedTimeOffsets instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedTimeOffsets' must have type Array."
+                );
+            }
+            // TODO: ensure values are floats
+            this.ReferencedTimeOffsets = options.referencedTimeOffsets;
+        } else if (options.referencedDateTime === undefined) {
+            if (
+                !(
+                    typeof options.referencedDateTime === "object" ||
+                    options.referencedDateTime instanceof Array
+                )
+            ) {
+                throw new Error(
+                    "Option 'referencedDateTime' must have type Array."
+                );
+            }
+            this.ReferencedDateTime = options.referencedDateTime;
+        } else {
+            throw new Error(
+                "One of the following options is required for TcoordContentItem: " +
+                    "'referencedSamplePositions', 'referencedTimeOffsets', or " +
+                    "'referencedDateTime'."
+            );
+        }
+    }
+}
+
+export {
+    CodeContentItem,
+    ContainerContentItem,
+    ContentSequence,
+    CompositeContentItem,
+    DateContentItem,
+    DateTimeContentItem,
+    GraphicTypes,
+    GraphicTypes3D,
+    ImageContentItem,
+    NumContentItem,
+    PNameContentItem,
+    PixelOriginInterpretations,
+    RelationshipTypes,
+    ScoordContentItem,
+    Scoord3DContentItem,
+    TcoordContentItem,
+    TemporalRangeTypes,
+    TextContentItem,
+    TimeContentItem,
+    UIDRefContentItem,
+    ValueTypes
+};


### PR DESCRIPTION
This PR implements structured reporting analogous to the *pydicom* implementation by exposing an intuitive, object-oriented interface for creation of SR documents based on template TID 1500 Measurement Report.

Commit 678543c introduces the `sr` sub-package with the intent to replace `adapters`. The adapter approach has several shortcomings in my opinion. First, the implementation is incomplete and generated SR documents are not standard compliant (several required attributes are missing, etc.). Second, the library would ideally not be aware of other tools, which in turn depend on the library.

The constructors of classes for DICOM templates, content items and value types defined in `sr.templates`, `sr.contentItems` and `sr.valueTypes`, respectively, perform many checks on the `options` object to ensure arguments have the correct type and appropriate values. A lot of these checks could be further abstracted using JSON schemas. However, this would add further package dependencies. Therefore, I would like to defer this decision.
