### PR TITLE
Fix Dataview offset out of bounds bug

### DIFF
--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -236,7 +236,8 @@ class BufferStream {
         if (this.offset + step > this.buffer.byteLength) {
             //throw new Error("Writing exceeded the size of buffer");
             //resize
-            var dst = new ArrayBuffer(this.buffer.byteLength * 2);
+            var dstSize = this.offset + step;
+            var dst = new ArrayBuffer(dstSize);
             new Uint8Array(dst).set(new Uint8Array(this.buffer));
             this.buffer = dst;
             this.view = new DataView(this.buffer);


### PR DESCRIPTION
**WHAT**
in checkSize of BufferStream.js, resize buffer appropriate size instead of just increase buffer size double.


**WHY**
If step size is bigger than buffer length, just increasing buffer size double produce offset error as follows.

```
Error: Offset is outside the bounds of the DataView
```