### PR TITLE
fix reading encoded strings

### DIFF
--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -62,6 +62,23 @@ class BufferStream {
         this.offset = 0;
         this.isLittleEndian = littleEndian || false;
         this.size = 0;
+
+        this.setEncoding("iso-ir-100");
+    }
+
+    setEncoding(characterset) {
+        this.characterset = characterset;
+        if (typeof TextDecoder == "function") {
+            // for browser
+            this.decoder = new TextDecoder(characterset);
+        } else {
+            // for node.js
+            try {
+                this.decoder = new (require("util")).TextDecoder(characterset);
+            } catch (e) {
+                this.decoder = new (require("util")).TextDecoder("utf-8");
+            }
+        }
     }
 
     setEndian(isLittle) {
@@ -212,16 +229,8 @@ class BufferStream {
     }
 
     readString(length) {
-        var string = "";
-
-        var numOfMulti = length,
-            index = 0;
-        while (index++ < numOfMulti) {
-            var charCode = this.readUint8();
-            string += String.fromCharCode(charCode);
-        }
-
-        return string;
+        var arr = this.readUint8Array(length);
+        return this.decoder.decode(arr);
     }
 
     readHex(length) {

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -36,10 +36,17 @@ class DicomMessage {
             while (!bufferStream.end()) {
                 var readInfo = DicomMessage.readTag(bufferStream, syntax);
 
-                dict[readInfo.tag.toCleanString()] = {
+                var cleantag = readInfo.tag.toCleanString();
+                dict[cleantag] = {
                     vr: readInfo.vr.type,
                     Value: readInfo.values
                 };
+                if (cleantag == "00080005") {
+                    // character encoding
+                    if (readInfo.values[0] == "ISO_IR 192") {
+                        bufferStream.setEncoding("utf-8");
+                    }
+                }
             }
             return dict;
         } catch (err) {


### PR DESCRIPTION
this is a proposal, may need some testing
the standard DICOM encoding is ISO-IR 6, which I think is something like ASCII. 
More common I think is ISO-IR 100 when not otherwise specified. 
At the moment I only check for UTF-8, known as ISO-IR 192 in the DICOM standard. There may be some other encodings in common use?