### PR TITLE
Fix parsing of WADO-RS headers.

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -82,7 +82,7 @@ class DicomMetaDictionary {
     // - single element lists are replaced by their first element
     // - object member names are dictionary, not group/element tag
     static naturalizeDataset(dataset) {
-        var naturalDataset = {
+        const naturalDataset = {
             _vrMap: {}
         };
 
@@ -104,22 +104,28 @@ class DicomMetaDictionary {
             if (data.Value === undefined) {
                 // In the case of type 2, add this tag but explictly set it null to indicate its empty.
                 naturalDataset[naturalName] = null;
-            } else if (data.vr === "SQ") {
-                // convert sequence to list of values
-                const naturalValues = [];
-
-                Object.keys(data.Value).forEach(index => {
-                    naturalValues.push(
-                        DicomMetaDictionary.naturalizeDataset(data.Value[index])
-                    );
-                });
-
-                naturalDataset[naturalName] =
-                    naturalValues.length === 1
-                        ? naturalValues[0]
-                        : naturalValues;
             } else {
-                naturalDataset[naturalName] = data.Value;
+                if (data.vr === "SQ") {
+                    // convert sequence to list of values
+                    const naturalValues = [];
+
+                    Object.keys(data.Value).forEach(index => {
+                        naturalValues.push(
+                            DicomMetaDictionary.naturalizeDataset(
+                                data.Value[index]
+                            )
+                        );
+                    });
+
+                    naturalDataset[naturalName] = naturalValues;
+                } else {
+                    naturalDataset[naturalName] = data.Value;
+                }
+
+                if (naturalDataset[naturalName].length === 1) {
+                    naturalDataset[naturalName] =
+                        naturalDataset[naturalName][0];
+                }
             }
         });
         return naturalDataset;

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -89,11 +89,6 @@ class DicomMetaDictionary {
         Object.keys(dataset).forEach(tag => {
             var data = dataset[tag];
 
-            if (data.Value === undefined) {
-                // In the case of type 2, don't add this tag.
-                return;
-            }
-
             if (data.vr === "SQ") {
                 // convert sequence to list of values
                 var naturalValues = [];
@@ -114,10 +109,17 @@ class DicomMetaDictionary {
                     naturalDataset._vrMap[naturalName] = data.vr;
                 }
             }
-            naturalDataset[naturalName] = data.Value;
-            if (naturalDataset[naturalName].length == 1) {
-                // only one value is not a list
-                naturalDataset[naturalName] = naturalDataset[naturalName][0];
+
+            if (data.Value === undefined) {
+                // In the case of type 2, add this tag but explictly set it null to indicate its empty.
+                naturalDataset[naturalName] = null;
+            } else {
+                naturalDataset[naturalName] = data.Value;
+                if (naturalDataset[naturalName].length == 1) {
+                    // only one value is not a list
+                    naturalDataset[naturalName] =
+                        naturalDataset[naturalName][0];
+                }
             }
         });
         return naturalDataset;

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -104,6 +104,16 @@ class DicomMetaDictionary {
             if (data.Value === undefined) {
                 // In the case of type 2, add this tag but explictly set it null to indicate its empty.
                 naturalDataset[naturalName] = null;
+
+                if (data.InlineBinary) {
+                    naturalDataset[naturalName] = {
+                        InlineBinary: data.InlineBinary
+                    };
+                } else if (data.BulkDataURI) {
+                    naturalDataset[naturalName] = {
+                        BulkDataURI: data.BulkDataURI
+                    };
+                }
             } else {
                 if (data.vr === "SQ") {
                     // convert sequence to list of values

--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -85,9 +85,16 @@ class DicomMetaDictionary {
         var naturalDataset = {
             _vrMap: {}
         };
+
         Object.keys(dataset).forEach(tag => {
             var data = dataset[tag];
-            if (data.vr == "SQ") {
+
+            if (data.Value === undefined) {
+                // In the case of type 2, don't add this tag.
+                return;
+            }
+
+            if (data.vr === "SQ") {
                 // convert sequence to list of values
                 var naturalValues = [];
                 Object.keys(data.Value).forEach(index => {


### PR DESCRIPTION
WADO-RS headers often come back with type 2 DICOM tags that have no Value entry. This currently breaks the naturalizer. This fixes that by skipping over these entries.

I'd argue that its more "natural" to not add empty type 2 tags to the "naturalized" (i.e. human readable datasets), but we can add them in later if removing them is deemed unnatural.