### PR TITLE
Convert Number to String before writing Decimal and Integer Strings.

### DIFF
--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -228,7 +228,7 @@ class StringRepresentation extends ValueRepresentation {
     }
 
     writeBytes(stream, value) {
-        var written = super.write(stream, "String", value);
+        const written = super.write(stream, "String", value);
 
         return super.writeBytes(stream, value, written);
     }
@@ -448,6 +448,10 @@ class DecimalString extends StringRepresentation {
 
         return ds;
     }
+
+    writeBytes(stream, value) {
+        return super.writeBytes(stream, value.map(String));
+    }
 }
 
 class DateTime extends StringRepresentation {
@@ -524,6 +528,10 @@ class IntegerString extends StringRepresentation {
         }
 
         return is;
+    }
+
+    writeBytes(stream, value) {
+        return super.writeBytes(stream, value.map(String));
     }
 }
 


### PR DESCRIPTION
Fix for #96 . Convert array of Numbers to array of Strings before writing.