### PR TITLE
Avoid mutation in static DicomMetaDictionary methods

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -24,11 +24,11 @@ class DicomMetaDictionary {
     // TODO: if this gets longer it could go in ValueRepresentation.js
     // or in a dedicated class
     static cleanDataset(dataset) {
-        var cleanedDataset = {};
+        const cleanedDataset = {};
         Object.keys(dataset).forEach(tag => {
-            var data = dataset[tag];
+            const data = Object.assign({}, dataset[tag]);
             if (data.vr == "SQ") {
-                var cleanedValues = [];
+                const cleanedValues = [];
                 Object.keys(data.Value).forEach(index => {
                     cleanedValues.push(
                         DicomMetaDictionary.cleanDataset(data.Value[index])
@@ -37,11 +37,12 @@ class DicomMetaDictionary {
                 data.Value = cleanedValues;
             } else {
                 // remove null characters from strings
-                Object.keys(data.Value).forEach(index => {
-                    let dataItem = data.Value[index];
-                    if (dataItem.constructor.name == "String") {
-                        data.Value[index] = dataItem.replace(/\0/, "");
+                data.Value = Object.keys(data.Value).map(index => {
+                    const item = data.Value[index];
+                    if (item.constructor.name == "String") {
+                        return item.replace(/\0/, "");
                     }
+                    return item;
                 });
             }
             cleanedDataset[tag] = data;
@@ -55,7 +56,7 @@ class DicomMetaDictionary {
     static namifyDataset(dataset) {
         var namedDataset = {};
         Object.keys(dataset).forEach(tag => {
-            var data = dataset[tag];
+            const data = Object.assign({}, dataset[tag]);
             if (data.vr == "SQ") {
                 var namedValues = [];
                 Object.keys(data.Value).forEach(index => {

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -45,6 +45,34 @@ const metadata = {
   }
 };
 
+const sequenceMetadata = {
+  "00081032": {
+    "vr": "SQ",
+    "Value": [
+      {
+        "00080100": {
+          "vr": "SH",
+          "Value": [
+            "IMG1332"
+          ]
+        },
+        "00080102": {
+          "vr": "SH",
+          "Value": [
+            "L"
+          ]
+        },
+        "00080104": {
+          "vr": "LO",
+          "Value": [
+            "MRI SHOULDER WITHOUT IV CONTRAST LEFT"
+          ]
+        }
+      }
+    ]
+  }
+}
+
 function downloadToFile(url, filePath) {
   return new Promise( (resolve,reject) => {
     const fileStream = fs.createWriteStream(filePath);
@@ -91,6 +119,17 @@ const tests = {
     const naturalDICOM = DicomMetaDictionary.naturalizeDataset(datasets[0]);
 
     expect(naturalDICOM.StudyInstanceUID).to.equal(firstUID);
+
+    //
+    // make a natural version of a dataset with sequence tags and confirm it has correct values
+    //
+    const naturalSequence = DicomMetaDictionary.naturalizeDataset(sequenceMetadata);
+
+    expect(naturalSequence.ProcedureCodeSequence).to.have.property('CodeValue', 'IMG1332');
+    expect(naturalSequence.ProcedureCodeSequence).to.have.property('CodingSchemeDesignator', 'L');
+    expect(naturalSequence.ProcedureCodeSequence).to.have.property('CodeMeaning', 'MRI SHOULDER WITHOUT IV CONTRAST LEFT');
+    // expect original data to remain unnaturalized
+    expect(sequenceMetadata['00081032'].Value[0]).to.have.keys('00080100', '00080102', '00080104');
 
     //
     // convert to part10 and back


### PR DESCRIPTION
The static methods `cleanDataset`, `namifyDataset`, and `naturalizeDataset` in DicomMetaDictionary have the side effect of changing the original dataset for sequence tags. `cleanDataset` also modified original values when converting nulls to empty strings.

I added Object.assign and array.map so that the output datasets get their own copies of non-primitives, and the input is safely unchanged.

I encountered this problem when trying to call `DicomMetaDictionary.naturalizeDataset` more than once on the same dataset. It would throw a `TypeError: Cannot read property 'length' of undefined` on the second pass.

Edit: Looks like `naturalizeDataset` was refactored while I was sleeping 😁, so this change now only applies to the clean and namify methods.