### PR TITLE
Ensure StringRepresentation values are coerced to strings before being written

### DIFF
--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -228,8 +228,8 @@ class StringRepresentation extends ValueRepresentation {
     }
 
     writeBytes(stream, value) {
+        value = value.map(String);
         var written = super.write(stream, "String", value);
-
         return super.writeBytes(stream, value, written);
     }
 }


### PR DESCRIPTION
I noticed that IS values such as InstanceNumber were not appearing when examining written DICOM data. The values are read in and stored in the DicomDict as numbers but are written out as strings. Ensuring that StringRepresentation values are coerced to strings results in valid tag data.