### PR TITLE
Fix tags with value 0 lost when saving

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -170,7 +170,7 @@ class DicomMetaDictionary {
             var entry = DicomMetaDictionary.nameMap[name];
             if (entry) {
                 let dataValue = dataset[naturalName];
-                if (!dataValue) {
+                if (dataValue === undefined) {
                     // handle the case where it was deleted from the object but is in keys
                     return;
                 }


### PR DESCRIPTION
### Issue #115 
Tags with falsy values are removed when a naturalized dataset object is converted into a blob. For example, tags with value 0 should be retained.