### PR TITLE
Segmentation Fix: Ignore empty seg frames

### DIFF
--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -340,7 +340,11 @@ function generateToolState(imageIds, arrayBuffer, metadataProvider) {
 
     let inPlane = true;
 
-    for (let i = 0; i < PerFrameFunctionalGroupsSequence.length; i++) {
+    for (
+        let i = 0, groupsLen = PerFrameFunctionalGroupsSequence.length;
+        i < groupsLen;
+        ++i
+    ) {
         const PerFrameFunctionalGroups = PerFrameFunctionalGroupsSequence[i];
 
         const ImageOrientationPatientI =
@@ -408,20 +412,22 @@ function generateToolState(imageIds, arrayBuffer, metadataProvider) {
 
         const data = alignedPixelDataI.data;
 
-        let frameHasSegments = false;
-        for (let j = 0; j < alignedPixelDataI.data.length; j++) {
+        for (let j = 0, len = alignedPixelDataI.data.length; j < len; ++j) {
             if (data[j]) {
-                frameHasSegments = true;
-                labelmap2DView[j] = segmentIndex;
+                for (let x = j + 1; x < len; ++x) {
+                    if (data[x]) {
+                        labelmap2DView[x] = segmentIndex;
+                    }
+                }
+
+                if (!segmentsOnFrame[imageIdIndex]) {
+                    segmentsOnFrame[imageIdIndex] = [];
+                }
+
+                segmentsOnFrame[imageIdIndex].push(segmentIndex);
+
+                break;
             }
-        }
-
-        if (!segmentsOnFrame[imageIdIndex]) {
-            segmentsOnFrame[imageIdIndex] = [];
-        }
-
-        if (frameHasSegments) {
-            segmentsOnFrame[imageIdIndex].push(segmentIndex);
         }
     }
 

--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -408,8 +408,10 @@ function generateToolState(imageIds, arrayBuffer, metadataProvider) {
 
         const data = alignedPixelDataI.data;
 
+        let frameHasSegments = false;
         for (let j = 0; j < alignedPixelDataI.data.length; j++) {
             if (data[j]) {
+                frameHasSegments = true;
                 labelmap2DView[j] = segmentIndex;
             }
         }
@@ -418,7 +420,9 @@ function generateToolState(imageIds, arrayBuffer, metadataProvider) {
             segmentsOnFrame[imageIdIndex] = [];
         }
 
-        segmentsOnFrame[imageIdIndex].push(segmentIndex);
+        if (frameHasSegments) {
+            segmentsOnFrame[imageIdIndex].push(segmentIndex);
+        }
     }
 
     if (!inPlane) {

--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -412,6 +412,7 @@ function generateToolState(imageIds, arrayBuffer, metadataProvider) {
 
         const data = alignedPixelDataI.data;
 
+       //
         for (let j = 0, len = alignedPixelDataI.data.length; j < len; ++j) {
             if (data[j]) {
                 for (let x = j + 1; x < len; ++x) {


### PR DESCRIPTION
In some cases, each frame is encoded for each segment even if it's empty. Checking each frame for occupancy would be slow, which is why we do the segmentsOnLabelmap2D.

Solution:
Check which frame is occupied by a single positive bit, and only add these ones to the list.

Related Issues:
- https://github.com/OHIF/Viewers/pull/1643