### PR TITLE
Adding null verification when denaturalizing the dataset values

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -170,7 +170,7 @@ class DicomMetaDictionary {
             var entry = DicomMetaDictionary.nameMap[name];
             if (entry) {
                 let dataValue = dataset[naturalName];
-                if (dataValue === undefined) {
+                if (dataValue === undefined || dataValue === null) {
                     // handle the case where it was deleted from the object but is in keys
                     return;
                 }


### PR DESCRIPTION
After the update done by PR [116](https://github.com/dcmjs-org/dcmjs/pull/116) to fix the issue #115 DCMJS can't parse null values which he sets himself when naturalizing the dataset value at [DicomMetaDictionary#L107](https://github.com/dcmjs-org/dcmjs/blob/master/src/DicomMetaDictionary.js#L107) causing an error to be thrown at [DicomMetaDictionary#L160](https://github.com/JoosaT/dcmjs/blob/9baed8983554d1583cc802c5d6d3dad0e02426bb/src/DicomMetaDictionary.js#L160).

This PR only adds an extra validation to the dataValue, skipping the parsing if the value is either `undefined` or `null`