### PR TITLE
Bug: Considering type 2 tags when denaturalizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <div align="center">
   <h1>dcmjs</h1>
-
   <p>JavaScript implementation of DICOM manipulation. This code is an outgrowth of several efforts to implement web applications for medical imaging.</p>
 </div>
 


### PR DESCRIPTION
When denaturalizing tags we are not considering type 2 tags with null values and removing then from the dataset, which is wrong. This PR will consider null values as correct and jump all parsing and directly return the tag value as null.