### PR TITLE
Fix: skipping length check for null string values

### DIFF
--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -52,11 +52,11 @@ class ValueRepresentation {
             if (this.maxLength != length)
                 log.error(
                     "Invalid length for fixed length tag, vr " +
-                        this.type +
-                        ", length " +
-                        this.maxLength +
-                        " != " +
-                        length
+                    this.type +
+                    ", length " +
+                    this.maxLength +
+                    " != " +
+                    length
                 );
         }
         return this.readBytes(stream, length, syntax);
@@ -104,7 +104,7 @@ class ValueRepresentation {
                     written.push(0);
                 } else {
                     var self = this;
-                    valueArgs[0].forEach(function(v, k) {
+                    valueArgs[0].forEach(function (v, k) {
                         if (self.allowMultiple() && k > 0) {
                             stream.writeHex("5C");
                             //byteCount++;
@@ -132,7 +132,9 @@ class ValueRepresentation {
                 checklen = lengths[i],
                 isString = false,
                 displaylen = checklen;
-            if (this.checkLength) {
+            if (checkValue === null) {
+                valid = true;
+            } else if (this.checkLength) {
                 valid = this.checkLength(checkValue);
             } else if (this.maxCharLength) {
                 var check = this.maxCharLength; //, checklen = checkValue.length;


### PR DESCRIPTION
Skipping length check for type 2 string tags when they are null.