### PR TITLE
fix: Expose arrow annotate

### DIFF
--- a/src/adapters/Cornerstone/EllipticalRoi.js
+++ b/src/adapters/Cornerstone/EllipticalRoi.js
@@ -33,9 +33,9 @@ class EllipticalRoi {
 
         // Calculate two opposite corners of box defined by two axes.
 
-        const minorAxisLength = cornerstoneMath.point.distance(
-            minorAxis[0],
-            minorAxis[1]
+        const minorAxisLength = Math.sqrt(
+            Math.pow(Math.abs(minorAxis[0].x - minorAxis[1].x), 2) +
+                Math.pow(Math.abs(minorAxis[0].y - minorAxis[1].y), 2)
         );
 
         const minorAxisDirection = {

--- a/src/adapters/Cornerstone/Freehand.js
+++ b/src/adapters/Cornerstone/Freehand.js
@@ -38,7 +38,7 @@ class Freehand {
 }
 
 Freehand.toolType = "Freehand";
-Freehand.utilityToolType = "Polyline";
+Freehand.utilityToolType = "Freehand";
 Freehand.TID300Representation = TID300Polyline;
 Freehand.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
     return false; // TODO

--- a/src/adapters/Cornerstone/index.js
+++ b/src/adapters/Cornerstone/index.js
@@ -11,6 +11,7 @@ const Cornerstone = {
     Freehand,
     Bidirectional,
     EllipticalRoi,
+    ArrowAnnotate,
     MeasurementReport,
     Segmentation
 };


### PR DESCRIPTION
This PR exposes the cornerstone `ArrowAnnotate` adapter and removes the implcit cornerstoneMath dependency from the ellipse adapter.