### PR TITLE
Cst bidirectional schema

### DIFF
--- a/examples/cornerstoneDICOMSR/index.html
+++ b/examples/cornerstoneDICOMSR/index.html
@@ -82,14 +82,13 @@
 
         <script src="https://unpkg.com/cornerstone-core@2.2.6/dist/cornerstone.js"></script>
         <script src="https://unpkg.com/cornerstone-math@0.1.6/dist/cornerstoneMath.js"></script>
-        <script src="https://unpkg.com/cornerstone-tools@4.3.0/dist/cornerstoneTools.js"></script>
+        <script src="https://unpkg.com/cornerstone-tools@4.16.1/dist/cornerstoneTools.js"></script>
 
         <script src="https://unpkg.com/dicom-parser/dist/dicomParser.js"></script>
         <script src="https://unpkg.com/cornerstone-wado-image-loader@3.0.2/dist/cornerstoneWADOImageLoader.min.js"></script>
         <script src="https://unpkg.com/hammerjs/hammer.min.js"></script>
 
         <script src="/js/initCornerstone.js"></script>
-
         <script src="/js/dcmjs.js"></script>
 
         <script

--- a/examples/cornerstoneDICOMSR/index.html
+++ b/examples/cornerstoneDICOMSR/index.html
@@ -89,6 +89,7 @@
         <script src="https://unpkg.com/hammerjs/hammer.min.js"></script>
 
         <script src="/js/initCornerstone.js"></script>
+
         <script src="/js/dcmjs.js"></script>
 
         <script

--- a/src/adapters/Cornerstone/Bidirectional.js
+++ b/src/adapters/Cornerstone/Bidirectional.js
@@ -72,6 +72,8 @@ class Bidirectional {
                     y: longAxisSCOORDGroup.GraphicData[1],
                     drawnIndependently: false,
                     allowedOutsideImage: false,
+                    active: false,
+                    highlight: false,
                     index: 0
                 },
                 end: {
@@ -79,6 +81,8 @@ class Bidirectional {
                     y: longAxisSCOORDGroup.GraphicData[3],
                     drawnIndependently: false,
                     allowedOutsideImage: false,
+                    active: false,
+                    highlight: false,
                     index: 1
                 },
                 perpendicularStart: {
@@ -86,6 +90,8 @@ class Bidirectional {
                     y: shortAxisSCOORDGroup.GraphicData[1],
                     drawnIndependently: false,
                     allowedOutsideImage: false,
+                    active: false,
+                    highlight: false,
                     index: 2
                 },
                 perpendicularEnd: {
@@ -93,6 +99,8 @@ class Bidirectional {
                     y: shortAxisSCOORDGroup.GraphicData[3],
                     drawnIndependently: false,
                     allowedOutsideImage: false,
+                    active: false,
+                    highlight: false,
                     index: 3
                 },
                 textBox: {
@@ -112,6 +120,7 @@ class Bidirectional {
             longestDiameter,
             shortestDiameter,
             toolType: "Bidirectional",
+            toolName: "Bidirectional",
             visible: true
         };
 

--- a/src/adapters/Cornerstone/EllipticalRoi.js
+++ b/src/adapters/Cornerstone/EllipticalRoi.js
@@ -34,8 +34,8 @@ class EllipticalRoi {
         // Calculate two opposite corners of box defined by two axes.
 
         const minorAxisLength = Math.sqrt(
-            Math.pow(Math.abs(minorAxis[0].x - minorAxis[1].x), 2) +
-                Math.pow(Math.abs(minorAxis[0].y - minorAxis[1].y), 2)
+            Math.pow(minorAxis[0].x - minorAxis[1].x, 2) +
+                Math.pow(minorAxis[0].y - minorAxis[1].y, 2)
         );
 
         const minorAxisDirection = {


### PR DESCRIPTION
Sometime between CST `4.3` and `4.16.1` some fields where added to the bidirectional tool schema which are actually breaking schema changes.

CST itself has no IO tests at the moment, so it appears this was missed. This fix fixes the import from SR using  `dcmjs`.