### PR TITLE
Cornerstone findings

### DIFF
--- a/examples/cornerstoneDICOMSR/index.html
+++ b/examples/cornerstoneDICOMSR/index.html
@@ -89,7 +89,6 @@
         <script src="https://unpkg.com/hammerjs/hammer.min.js"></script>
 
         <script src="/js/initCornerstone.js"></script>
-
         <script src="/js/dcmjs.js"></script>
 
         <script

--- a/examples/cornerstoneDICOMSR/index.html
+++ b/examples/cornerstoneDICOMSR/index.html
@@ -89,6 +89,7 @@
         <script src="https://unpkg.com/hammerjs/hammer.min.js"></script>
 
         <script src="/js/initCornerstone.js"></script>
+
         <script src="/js/dcmjs.js"></script>
 
         <script

--- a/src/adapters/Cornerstone/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone/ArrowAnnotate.js
@@ -23,7 +23,7 @@ class ArrowAnnotate {
             group => group.ValueType === "SCOORD"
         );
 
-        const findingGroups = toArray(ContentSequence).filter(
+        const findingGroup = toArray(ContentSequence).find(
             group => group.ConceptNameCodeSequence.CodeValue === FINDING
         );
 
@@ -31,11 +31,7 @@ class ArrowAnnotate {
             group => group.ConceptNameCodeSequence.CodeValue === FINDING_SITE
         );
 
-        const cornerstoneFreeTextGroup = findingGroups.find(
-            group => group.ConceptCodeSequence.CodeValue === CORNERSTONEFREETEXT
-        );
-
-        const text = cornerstoneFreeTextGroup.ConceptCodeSequence.CodeMeaning;
+        const text = findingGroup.ConceptCodeSequence.CodeMeaning;
 
         const { GraphicData } = SCOORDGroup;
 
@@ -75,9 +71,9 @@ class ArrowAnnotate {
             invalidated: true,
             text,
             visible: true,
-            findings: findingGroups.map(fg => {
-                return { ...fg.ConceptCodeSequence };
-            }),
+            finding: findingGroup
+                ? findingGroup.ConceptCodeSequence
+                : undefined,
             findingSites: findingSiteGroups.map(fsg => {
                 return { ...fsg.ConceptCodeSequence };
             })
@@ -89,32 +85,24 @@ class ArrowAnnotate {
     static getTID300RepresentationArguments(tool) {
         const points = [tool.handles.start];
 
-        let { findings, findingSites } = tool;
+        let { finding, findingSites } = tool;
 
         const TID300RepresentationArguments = {
             points,
-            trackingIdentifierTextValue: `cornerstoneTools@^4.0.0:ArrowAnnotate`
+            trackingIdentifierTextValue: `cornerstoneTools@^4.0.0:ArrowAnnotate`,
+            findingSites: findingSites || []
         };
 
-        // If freetext isn't present in the findings, add it from the tool text.
-        if (!findings || !findings.length) {
-            findings = [
-                {
-                    CodeValue: CORNERSTONEFREETEXT,
-                    CodingSchemeDesignator: "CST4",
-                    CodeMeaning: tool.text
-                }
-            ];
-        } else if (!findings.some(f => f.CodeValue === CORNERSTONEFREETEXT)) {
-            findings.push({
+        // If freetext finding isn't present, add it from the tool text.
+        if (!finding || f.CodeValue !== CORNERSTONEFREETEXT) {
+            finding = {
                 CodeValue: CORNERSTONEFREETEXT,
                 CodingSchemeDesignator: "CST4",
                 CodeMeaning: tool.text
-            });
+            };
         }
 
-        TID300RepresentationArguments.findings = findings || [];
-        TID300RepresentationArguments.findingSites = findingSites || [];
+        TID300RepresentationArguments.finding = finding;
 
         return TID300RepresentationArguments;
     }

--- a/src/adapters/Cornerstone/Bidirectional.js
+++ b/src/adapters/Cornerstone/Bidirectional.js
@@ -16,7 +16,7 @@ class Bidirectional {
     static getMeasurementData(MeasurementGroup) {
         const { ContentSequence } = MeasurementGroup;
 
-        const findingGroups = toArray(ContentSequence).filter(
+        const findingGroup = toArray(ContentSequence).find(
             group => group.ConceptNameCodeSequence.CodeValue === FINDING
         );
 
@@ -132,9 +132,9 @@ class Bidirectional {
             toolType: "Bidirectional",
             toolName: "Bidirectional",
             visible: true,
-            findings: findingGroups.map(fg => {
-                return { ...fg.ConceptCodeSequence };
-            }),
+            finding: findingGroup
+                ? findingGroup.ConceptCodeSequence
+                : undefined,
             findingSites: findingSiteGroups.map(fsg => {
                 return { ...fsg.ConceptCodeSequence };
             })
@@ -153,7 +153,7 @@ class Bidirectional {
         const {
             shortestDiameter,
             longestDiameter,
-            findings,
+            finding,
             findingSites
         } = tool;
 
@@ -172,7 +172,7 @@ class Bidirectional {
             longAxisLength: longestDiameter,
             shortAxisLength: shortestDiameter,
             trackingIdentifierTextValue,
-            findings: findings || [],
+            finding: finding,
             findingSites: findingSites || []
         };
     }

--- a/src/adapters/Cornerstone/Bidirectional.js
+++ b/src/adapters/Cornerstone/Bidirectional.js
@@ -6,6 +6,8 @@ import { toArray } from "../helpers.js";
 const BIDIRECTIONAL = "Bidirectional";
 const LONG_AXIS = "Long Axis";
 const SHORT_AXIS = "Short Axis";
+const FINDING = "121071";
+const FINDING_SITE = "G-C0E3";
 
 class Bidirectional {
     constructor() {}
@@ -13,6 +15,14 @@ class Bidirectional {
     // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(MeasurementGroup) {
         const { ContentSequence } = MeasurementGroup;
+
+        const findingGroups = toArray(ContentSequence).filter(
+            group => group.ConceptNameCodeSequence.CodeValue === FINDING
+        );
+
+        const findingSiteGroups = toArray(ContentSequence).filter(
+            group => group.ConceptNameCodeSequence.CodeValue === FINDING_SITE
+        );
 
         const longAxisNUMGroup = toArray(ContentSequence).find(
             group => group.ConceptNameCodeSequence.CodeMeaning === LONG_AXIS
@@ -121,11 +131,14 @@ class Bidirectional {
             shortestDiameter,
             toolType: "Bidirectional",
             toolName: "Bidirectional",
-            visible: true
+            visible: true,
+            findings: findingGroups.map(fg => {
+                return { ...fg.ConceptCodeSequence };
+            }),
+            findingSites: findingSiteGroups.map(fsg => {
+                return { ...fsg.ConceptCodeSequence };
+            })
         };
-
-        // TODO: To be implemented!
-        // Needs to add longAxis, shortAxis, longAxisLength, shortAxisLength
 
         return state;
     }
@@ -137,7 +150,12 @@ class Bidirectional {
             perpendicularStart,
             perpendicularEnd
         } = tool.handles;
-        const { shortestDiameter, longestDiameter } = tool;
+        const {
+            shortestDiameter,
+            longestDiameter,
+            findings,
+            findingSites
+        } = tool;
 
         const trackingIdentifierTextValue =
             "cornerstoneTools@^4.0.0:Bidirectional";
@@ -153,7 +171,9 @@ class Bidirectional {
             },
             longAxisLength: longestDiameter,
             shortAxisLength: shortestDiameter,
-            trackingIdentifierTextValue
+            trackingIdentifierTextValue,
+            findings: findings || [],
+            findingSites: findingSites || []
         };
     }
 }

--- a/src/adapters/Cornerstone/EllipticalRoi.js
+++ b/src/adapters/Cornerstone/EllipticalRoi.js
@@ -14,7 +14,7 @@ class EllipticalRoi {
     static getMeasurementData(MeasurementGroup) {
         const { ContentSequence } = MeasurementGroup;
 
-        const findingGroups = toArray(ContentSequence).filter(
+        const findingGroup = toArray(ContentSequence).find(
             group => group.ConceptNameCodeSequence.CodeValue === FINDING
         );
 
@@ -103,9 +103,9 @@ class EllipticalRoi {
             },
             invalidated: true,
             visible: true,
-            findings: findingGroups.map(fg => {
-                return { ...fg.ConceptCodeSequence };
-            }),
+            finding: findingGroup
+                ? findingGroup.ConceptCodeSequence
+                : undefined,
             findingSites: findingSiteGroups.map(fsg => {
                 return { ...fsg.ConceptCodeSequence };
             })
@@ -115,7 +115,7 @@ class EllipticalRoi {
     }
 
     static getTID300RepresentationArguments(tool) {
-        const { cachedStats, handles, findings, findingSites } = tool;
+        const { cachedStats, handles, finding, findingSites } = tool;
         const { start, end } = handles;
         const { area } = cachedStats;
 
@@ -151,7 +151,7 @@ class EllipticalRoi {
             area,
             points,
             trackingIdentifierTextValue,
-            findings: findings || [],
+            finding,
             findingSites: findingSites || []
         };
     }

--- a/src/adapters/Cornerstone/EllipticalRoi.js
+++ b/src/adapters/Cornerstone/EllipticalRoi.js
@@ -4,6 +4,8 @@ import CORNERSTONE_4_TAG from "./cornerstone4Tag";
 import { toArray } from "../helpers.js";
 
 const ELLIPTICALROI = "EllipticalRoi";
+const FINDING = "121071";
+const FINDING_SITE = "G-C0E3";
 
 class EllipticalRoi {
     constructor() {}
@@ -11,6 +13,14 @@ class EllipticalRoi {
     // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(MeasurementGroup) {
         const { ContentSequence } = MeasurementGroup;
+
+        const findingGroups = toArray(ContentSequence).filter(
+            group => group.ConceptNameCodeSequence.CodeValue === FINDING
+        );
+
+        const findingSiteGroups = toArray(ContentSequence).filter(
+            group => group.ConceptNameCodeSequence.CodeValue === FINDING_SITE
+        );
 
         const NUMGroup = toArray(ContentSequence).find(
             group => group.ValueType === "NUM"
@@ -92,14 +102,20 @@ class EllipticalRoi {
                 }
             },
             invalidated: true,
-            visible: true
+            visible: true,
+            findings: findingGroups.map(fg => {
+                return { ...fg.ConceptCodeSequence };
+            }),
+            findingSites: findingSiteGroups.map(fsg => {
+                return { ...fsg.ConceptCodeSequence };
+            })
         };
 
         return state;
     }
 
     static getTID300RepresentationArguments(tool) {
-        const { cachedStats, handles } = tool;
+        const { cachedStats, handles, findings, findingSites } = tool;
         const { start, end } = handles;
         const { area } = cachedStats;
 
@@ -134,7 +150,9 @@ class EllipticalRoi {
         return {
             area,
             points,
-            trackingIdentifierTextValue
+            trackingIdentifierTextValue,
+            findings: findings || [],
+            findingSites: findingSites || []
         };
     }
 }

--- a/src/adapters/Cornerstone/Length.js
+++ b/src/adapters/Cornerstone/Length.js
@@ -4,6 +4,8 @@ import CORNERSTONE_4_TAG from "./cornerstone4Tag";
 import { toArray } from "../helpers.js";
 
 const LENGTH = "Length";
+const FINDING = "121071";
+const FINDING_SITE = "G-C0E3";
 
 class Length {
     constructor() {}
@@ -11,6 +13,14 @@ class Length {
     // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(MeasurementGroup) {
         const { ContentSequence } = MeasurementGroup;
+
+        const findingGroups = toArray(ContentSequence).filter(
+            group => group.ConceptNameCodeSequence.CodeValue === FINDING
+        );
+
+        const findingSiteGroups = toArray(ContentSequence).filter(
+            group => group.ConceptNameCodeSequence.CodeValue === FINDING_SITE
+        );
 
         const NUMGroup = toArray(ContentSequence).find(
             group => group.ValueType === "NUM"
@@ -29,10 +39,26 @@ class Length {
             sopInstanceUid: ReferencedSOPInstanceUID,
             frameIndex: ReferencedFrameNumber || 1,
             length: NUMGroup.MeasuredValueSequence.NumericValue,
-            toolType: Length.toolType
+            toolType: Length.toolType,
+            handles: {
+                start: {},
+                end: {},
+                textBox: {
+                    hasMoved: false,
+                    movesIndependently: false,
+                    drawnIndependently: true,
+                    allowedOutsideImage: true,
+                    hasBoundingBox: true
+                }
+            },
+            findings: findingGroups.map(fg => {
+                return { ...fg.ConceptCodeSequence };
+            }),
+            findingSites: findingSiteGroups.map(fsg => {
+                return { ...fsg.ConceptCodeSequence };
+            })
         };
 
-        lengthState.handles = { start: {}, end: {} };
         [
             lengthState.handles.start.x,
             lengthState.handles.start.y,
@@ -40,25 +66,25 @@ class Length {
             lengthState.handles.end.y
         ] = SCOORDGroup.GraphicData;
 
-        lengthState.handles.textBox = {
-            hasMoved: false,
-            movesIndependently: false,
-            drawnIndependently: true,
-            allowedOutsideImage: true,
-            hasBoundingBox: true
-        };
-
         return lengthState;
     }
 
     static getTID300RepresentationArguments(tool) {
-        const point1 = tool.handles.start;
-        const point2 = tool.handles.end;
+        const { handles, findings, findingSites } = tool;
+        const point1 = handles.start;
+        const point2 = handles.end;
         const distance = tool.length;
 
         const trackingIdentifierTextValue = "cornerstoneTools@^4.0.0:Length";
 
-        return { point1, point2, distance, trackingIdentifierTextValue };
+        return {
+            point1,
+            point2,
+            distance,
+            trackingIdentifierTextValue,
+            findings: findings || [],
+            findingSites: findingSites || []
+        };
     }
 }
 

--- a/src/adapters/Cornerstone/Length.js
+++ b/src/adapters/Cornerstone/Length.js
@@ -14,7 +14,7 @@ class Length {
     static getMeasurementData(MeasurementGroup) {
         const { ContentSequence } = MeasurementGroup;
 
-        const findingGroups = toArray(ContentSequence).filter(
+        const findingGroup = toArray(ContentSequence).find(
             group => group.ConceptNameCodeSequence.CodeValue === FINDING
         );
 
@@ -51,9 +51,9 @@ class Length {
                     hasBoundingBox: true
                 }
             },
-            findings: findingGroups.map(fg => {
-                return { ...fg.ConceptCodeSequence };
-            }),
+            finding: findingGroup
+                ? findingGroup.ConceptCodeSequence
+                : undefined,
             findingSites: findingSiteGroups.map(fsg => {
                 return { ...fsg.ConceptCodeSequence };
             })
@@ -70,7 +70,7 @@ class Length {
     }
 
     static getTID300RepresentationArguments(tool) {
-        const { handles, findings, findingSites } = tool;
+        const { handles, finding, findingSites } = tool;
         const point1 = handles.start;
         const point2 = handles.end;
         const distance = tool.length;
@@ -82,7 +82,7 @@ class Length {
             point2,
             distance,
             trackingIdentifierTextValue,
-            findings: findings || [],
+            finding,
             findingSites: findingSites || []
         };
     }

--- a/src/utilities/TID300/TID300Measurement.js
+++ b/src/utilities/TID300/TID300Measurement.js
@@ -10,6 +10,7 @@ export default class TID300Measurement {
         return [
             ...this.getTrackingGroups(),
             ...this.getFindingGroups(),
+            ...this.getFindingSiteGroups(),
             ...contentSequenceEntries
         ];
     }
@@ -58,6 +59,32 @@ export default class TID300Measurement {
                     CodeValue, //: "SAMPLE FINDING",
                     CodingSchemeDesignator, //: "99dcmjs",
                     CodeMeaning //: "Sample Finding"
+                }
+            };
+        });
+    }
+
+    getFindingSiteGroups() {
+        let findingSites = this.props.findingSites || [];
+
+        return findingSites.map(findingSite => {
+            const {
+                CodeValue,
+                CodingSchemeDesignator,
+                CodeMeaning
+            } = findingSite;
+            return {
+                RelationshipType: "CONTAINS",
+                ValueType: "CODE",
+                ConceptNameCodeSequence: {
+                    CodeValue: "G-C0E3",
+                    CodingSchemeDesignator: "SRT",
+                    CodeMeaning: "Finding Site"
+                },
+                ConceptCodeSequence: {
+                    CodeValue, //: "SAMPLE FINDING SITE",
+                    CodingSchemeDesignator, //: "99dcmjs",
+                    CodeMeaning //: "Sample Finding Site"
                 }
             };
         });

--- a/src/utilities/TID300/TID300Measurement.js
+++ b/src/utilities/TID300/TID300Measurement.js
@@ -9,7 +9,7 @@ export default class TID300Measurement {
     getMeasurement(contentSequenceEntries) {
         return [
             ...this.getTrackingGroups(),
-            ...this.getFindingGroups(),
+            ...this.getFindingGroup(),
             ...this.getFindingSiteGroups(),
             ...contentSequenceEntries
         ];
@@ -42,12 +42,17 @@ export default class TID300Measurement {
         ];
     }
 
-    getFindingGroups() {
-        let findings = this.props.findings || [];
+    getFindingGroup() {
+        let finding = this.props.finding;
 
-        return findings.map(finding => {
-            const { CodeValue, CodingSchemeDesignator, CodeMeaning } = finding;
-            return {
+        if (!finding) {
+            return [];
+        }
+
+        const { CodeValue, CodingSchemeDesignator, CodeMeaning } = finding;
+
+        return [
+            {
                 RelationshipType: "CONTAINS",
                 ValueType: "CODE",
                 ConceptNameCodeSequence: {
@@ -60,8 +65,8 @@ export default class TID300Measurement {
                     CodingSchemeDesignator, //: "99dcmjs",
                     CodeMeaning //: "Sample Finding"
                 }
-            };
-        });
+            }
+        ];
     }
 
     getFindingSiteGroups() {


### PR DESCRIPTION
If a cornerstone measurement has `findings` or `findingSites`, encode these in the SR. If an SR has `Finding`s or `Finding Site`s, attach these to the cornerstone measurements when the cornerstone adapter is used.

There are also generic `Finding Site` groups added to the TID300 class, that allow you to pass in a `findingSites` array of the form:

```
[
  {
    CodeValue: "SAMPLE FINDING SITE",
    CodingSchemeDesignator: "99dcmjs",
    CodeMeaning: "Sample Finding Site"
  },
  // More entries
]

```

Which will build appropriate `Finding Site` content items, similar to the already existing functionaly for `Findings`.
