### PR TITLE
fix: 🐛 Fix arrow annotate cornerstone parsing

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -32,8 +32,12 @@ const encapsulatedSyntaxes = [
 class DicomMessage {
     static read(bufferStream, syntax, ignoreErrors) {
         var dict = {};
+        debugger;
         try {
             while (!bufferStream.end()) {
+                if (bufferStream.size === bufferStream.offset) {
+                    debugger;
+                }
                 var readInfo = DicomMessage.readTag(bufferStream, syntax);
 
                 dict[readInfo.tag.toCleanString()] = {

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -32,12 +32,8 @@ const encapsulatedSyntaxes = [
 class DicomMessage {
     static read(bufferStream, syntax, ignoreErrors) {
         var dict = {};
-        debugger;
         try {
             while (!bufferStream.end()) {
-                if (bufferStream.size === bufferStream.offset) {
-                    debugger;
-                }
                 var readInfo = DicomMessage.readTag(bufferStream, syntax);
 
                 dict[readInfo.tag.toCleanString()] = {

--- a/src/adapters/Cornerstone/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone/ArrowAnnotate.js
@@ -94,7 +94,7 @@ class ArrowAnnotate {
         };
 
         // If freetext finding isn't present, add it from the tool text.
-        if (!finding || f.CodeValue !== CORNERSTONEFREETEXT) {
+        if (!finding || finding.CodeValue !== CORNERSTONEFREETEXT) {
             finding = {
                 CodeValue: CORNERSTONEFREETEXT,
                 CodingSchemeDesignator: "CST4",


### PR DESCRIPTION
Fixes a typo that broke import of arrow annotations.