### PR TITLE
fix: 🐛 Fix Microscopy import

### DIFF
--- a/src/adapters/DICOMMicroscopyViewer/Circle.js
+++ b/src/adapters/DICOMMicroscopyViewer/Circle.js
@@ -7,7 +7,7 @@ class Circle {
     static getMeasurementData(measurementContent) {
         // removing duplication and Getting only the graphicData information
         const measurement = measurementContent
-            .map(item => item.ContentSequence.GraphicData)
+            .map(item => item.GraphicData)
             .filter(
                 (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
                     new Set()

--- a/src/adapters/DICOMMicroscopyViewer/Ellipse.js
+++ b/src/adapters/DICOMMicroscopyViewer/Ellipse.js
@@ -1,0 +1,46 @@
+import MeasurementReport from "./MeasurementReport.js";
+import TID300Ellipse from "../../utilities/TID300/Ellipse";
+
+class Ellipse {
+    constructor() {}
+
+    static getMeasurementData(measurementContent) {
+        // removing duplication and Getting only the graphicData information
+        const measurement = measurementContent
+            .map(item => item.GraphicData)
+            .filter(
+                (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
+                    new Set()
+                )
+            );
+
+        // Chunking the array into size of three
+        return measurement.map(measurement => {
+            return measurement.reduce((all, one, i) => {
+                const ch = Math.floor(i / 3);
+                all[ch] = [].concat(all[ch] || [], one);
+                return all;
+            }, []);
+        });
+    }
+
+    static getTID300RepresentationArguments(scoord3d) {
+        if (scoord3d.graphicType !== "Ellipse") {
+            throw new Error("We expected a Ellipse graphicType");
+        }
+
+        const points = scoord3d.graphicData;
+        const lengths = 1;
+
+        return { points, lengths };
+    }
+}
+
+Ellipse.graphicType = "ELLIPSE";
+Ellipse.toolType = "Ellipse";
+Ellipse.utilityToolType = "Ellipse";
+Ellipse.TID300Representation = TID300Ellipse;
+
+MeasurementReport.registerTool(Ellipse);
+
+export default Ellipse;

--- a/src/adapters/DICOMMicroscopyViewer/Point.js
+++ b/src/adapters/DICOMMicroscopyViewer/Point.js
@@ -5,9 +5,7 @@ class Point {
     constructor() {}
 
     static getMeasurementData(measurementContent) {
-        const measurement = measurementContent.map(
-            item => item.ContentSequence.GraphicData
-        );
+        const measurement = measurementContent.map(item => item.GraphicData);
         return measurement.filter(
             (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
                 new Set()

--- a/src/adapters/DICOMMicroscopyViewer/Polygon.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polygon.js
@@ -7,7 +7,7 @@ class Polygon {
     static getMeasurementData(measurementContent) {
         // removing duplication and Getting only the graphicData information
         const measurement = measurementContent
-            .map(item => item.ContentSequence.GraphicData)
+            .map(item => item.GraphicData)
             .filter(
                 (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
                     new Set()

--- a/src/adapters/DICOMMicroscopyViewer/Polyline.js
+++ b/src/adapters/DICOMMicroscopyViewer/Polyline.js
@@ -7,7 +7,7 @@ class Polyline {
     static getMeasurementData(measurementContent) {
         // removing duplication and Getting only the graphicData information
         const measurement = measurementContent
-            .map(item => item.ContentSequence.GraphicData)
+            .map(item => item.GraphicData)
             .filter(
                 (s => a => (j => !s.has(j) && s.add(j))(JSON.stringify(a)))(
                     new Set()

--- a/src/adapters/DICOMMicroscopyViewer/index.js
+++ b/src/adapters/DICOMMicroscopyViewer/index.js
@@ -3,12 +3,14 @@ import Polyline from "./Polyline.js";
 import Polygon from "./Polygon.js";
 import Point from "./Point.js";
 import Circle from "./Circle.js";
+import Ellipse from "./Ellipse.js";
 
 const DICOMMicroscopyViewer = {
     Polyline,
     Polygon,
     Point,
     Circle,
+    Ellipse,
     MeasurementReport
 };
 

--- a/src/adapters/helpers.js
+++ b/src/adapters/helpers.js
@@ -12,10 +12,7 @@ const codeMeaningEquals = codeMeaningName => {
 
 const graphicTypeEquals = graphicType => {
     return contentItem => {
-        return (
-            contentItem.ContentSequence !== undefined &&
-            contentItem.ContentSequence.GraphicType === graphicType
-        );
+        return contentItem && contentItem.GraphicType === graphicType;
     };
 };
 


### PR DESCRIPTION
This PR fixes the microscopy `MeasurementReport.generateToolState()` function so that it correctly identifies and extracts all measurement groups.

The implementation on master currently:
- Has an incorrect `graphicTypeEquals` function considering the data passed to it, meaning the data returned is empty.
-  Has `getMeasurementData`  methods for the microscopy SCOORD3D adapaters which check for `GraphicData` to be under a `ContentSequence`, whilst its actually at the root of the `contentItem` passed to the function.
- Only looks for one measurement group, instead of processing them all.

This PR fixes these issues.
I tested this from within another app, but I fixed it such that the pattern presented in `dcmjs-examples` works, e.g.:


```js
function getROIFromToolState(toolState) {
  const tools = Object.getOwnPropertyNames(toolState);

  const rois = [];

  tools.forEach(t => {
    const properties = {};
    const coordinates = toolState[t];
    let scoord3d;

    coordinates.forEach(coord => {
      if (t === 'Polygon' || t === 'Polyline') {
        scoord3d = new DICOMMicroscopyViewer.scoord3d.Polygon(coord);
      } else if (t === 'Point') {
        scoord3d = new DICOMMicroscopyViewer.scoord3d.Point(coord);
      } else if (t === 'Circle') {
        scoord3d = new DICOMMicroscopyViewer.scoord3d.Circle(coord);
      } else {
        throw new Error('Unsupported tool type');
      }

      const roi = new DICOMMicroscopyViewer.roi.ROI({ scoord3d, properties });
      rois.push(roi);
    });
  });

  return rois;
}


const MeasurementReport =
  dcmjs.adapters.DICOMMicroscopyViewer.MeasurementReport;

const toolState = MeasurementReport.generateToolState(dataset);
const rois = getROIFromToolState(toolState);
rois.forEach(roi => viewer.addROI(roi));
                  
```

Where viewer is the `DICOMMicroscopyViewer.api.VLWholeSlideMicroscopyImageViewer` instance.