### PR TITLE
fix: 🐛 Harden Segmentation import for different possible SEGs

### DIFF
--- a/examples/createSegmentation/index.html
+++ b/examples/createSegmentation/index.html
@@ -63,7 +63,8 @@
     <script src="https://unpkg.com/cornerstone-wado-image-loader@3.0.2/dist/cornerstoneWADOImageLoader.min.js"></script>
     <script src="https://unpkg.com/hammerjs/hammer.min.js"></script>
 
-    <script src="/js/initCornerstone.js"></script>
+
+    <script src="js/initCornerstone.js"></script>
     <script src="/js/dcmjs.js"></script>
 
     <script

--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -575,11 +575,6 @@ function insertPixelDataPlanar(
 
         let SourceImageSequence;
 
-        console.log(multiframe);
-        console.log(SharedFunctionalGroupsSequence);
-        console.log(PerFrameFunctionalGroups);
-        debugger;
-
         if (multiframe.SourceImageSequence) {
             SourceImageSequence = multiframe.SourceImageSequence[i];
         } else {
@@ -587,10 +582,6 @@ function insertPixelDataPlanar(
                 PerFrameFunctionalGroups.DerivationImageSequence
                     .SourceImageSequence;
         }
-
-        console.log(SourceImageSequence);
-
-        debugger;
 
         const imageId = getImageIdOfSourceImage(
             SourceImageSequence,

--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -858,35 +858,27 @@ function getValidOrientations(iop) {
 function alignPixelDataWithSourceData(pixelData2D, iop, orientations) {
     if (compareIOP(iop, orientations[0])) {
         //Same orientation.
-        console.log("Same orientation.");
         return pixelData2D;
     } else if (compareIOP(iop, orientations[1])) {
         //Flipped vertically.
-        console.log("Flipped vertically.");
         return flipMatrix2D.v(pixelData2D);
     } else if (compareIOP(iop, orientations[2])) {
         //Flipped horizontally.
-        console.log("Flipped horizontally.");
         return flipMatrix2D.h(pixelData2D);
     } else if (compareIOP(iop, orientations[3])) {
         //Rotated 90 degrees.
-        console.log("Rotated 90 degrees.");
         return rotateMatrix902D(pixelData2D);
     } else if (compareIOP(iop, orientations[4])) {
         //Rotated 90 degrees and fliped horizontally.
-        console.log("Rotated 90 degrees and fliped horizontally.");
         return flipMatrix2D.h(rotateMatrix902D(pixelData2D));
     } else if (compareIOP(iop, orientations[5])) {
         //Rotated 90 degrees and fliped vertically.
-        console.log("Rotated 90 degrees and fliped vertically.");
         return flipMatrix2D.v(rotateMatrix902D(pixelData2D));
     } else if (compareIOP(iop, orientations[6])) {
         //Rotated 180 degrees. // TODO -> Do this more effeciently, there is a 1:1 mapping like 90 degree rotation.
-        console.log("Rotated 180 degrees.");
         return rotateMatrix902D(rotateMatrix902D(pixelData2D));
     } else if (compareIOP(iop, orientations[7])) {
         //Rotated 270 degrees.  // TODO -> Do this more effeciently, there is a 1:1 mapping like 90 degree rotation.
-        console.log("Rotated 270 degrees.");
         return rotateMatrix902D(
             rotateMatrix902D(rotateMatrix902D(pixelData2D))
         );

--- a/src/derivations/Segmentation.js
+++ b/src/derivations/Segmentation.js
@@ -389,9 +389,7 @@ export default class Segmentation extends DerivedPixels {
                 break;
             default:
                 throw new Error(
-                    `SegmentAlgorithmType ${
-                        Segment.SegmentAlgorithmType
-                    } invalid.`
+                    `SegmentAlgorithmType ${Segment.SegmentAlgorithmType} invalid.`
                 );
         }
 


### PR DESCRIPTION
DICOM Segmentation objects can have their referenced data encoded in multiple ways. The cornerstone adapter now parses a greater selection, tested on a lot of TCIA cases.