### PR TITLE
Fix multiframe read/write

### DIFF
--- a/src/DicomDict.js
+++ b/src/DicomDict.js
@@ -17,7 +17,7 @@ class DicomDict {
         }
     }
 
-    write() {
+    write(writeOptions = {}) {
         var metaSyntax = EXPLICIT_LITTLE_ENDIAN;
         var fileStream = new WriteBufferStream(4096, true);
         fileStream.writeHex("00".repeat(128));
@@ -30,7 +30,7 @@ class DicomDict {
                 Value: [EXPLICIT_LITTLE_ENDIAN]
             };
         }
-        DicomMessage.write(this.meta, metaStream, metaSyntax);
+        DicomMessage.write(this.meta, metaStream, metaSyntax, writeOptions);
         DicomMessage.writeTagObject(
             fileStream,
             "00020000",
@@ -41,7 +41,7 @@ class DicomDict {
         fileStream.concat(metaStream);
 
         var useSyntax = this.meta["00020010"].Value[0];
-        DicomMessage.write(this.dict, fileStream, useSyntax);
+        DicomMessage.write(this.dict, fileStream, useSyntax, writeOptions);
         return fileStream.getBuffer();
     }
 }

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -100,7 +100,7 @@ class DicomMessage {
         tag.write(stream, vr, values, syntax);
     }
 
-    static write(jsonObjects, useStream, syntax) {
+    static write(jsonObjects, useStream, syntax, writeOptions) {
         var written = 0;
 
         var sortedTags = Object.keys(jsonObjects).sort();
@@ -110,7 +110,13 @@ class DicomMessage {
                 vrType = tagObject.vr,
                 values = tagObject.Value;
 
-            written += tag.write(useStream, vrType, values, syntax);
+            written += tag.write(
+                useStream,
+                vrType,
+                values,
+                syntax,
+                writeOptions
+            );
         });
 
         return written;

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -86,7 +86,7 @@ class Tag {
         return Tag.fromNumbers(group, element);
     }
 
-    write(stream, vrType, values, syntax) {
+    write(stream, vrType, values, syntax, writeOptions) {
         var vr = ValueRepresentation.createByTypeString(vrType),
             useSyntax = DicomMessage._normalizeSyntax(syntax);
 
@@ -113,10 +113,16 @@ class Tag {
                 tagStream,
                 values,
                 useSyntax,
-                isEncapsulated
+                isEncapsulated,
+                writeOptions
             );
         } else {
-            valueLength = vr.writeBytes(tagStream, values, useSyntax);
+            valueLength = vr.writeBytes(
+                tagStream,
+                values,
+                useSyntax,
+                writeOptions
+            );
         }
 
         if (vrType == "SQ") {

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect;
 const dcmjs = require('../build/dcmjs');
 
 const fs = require("fs");
-const {http, https} = require("follow-redirects");
+const { http, https } = require("follow-redirects");
 const os = require("os");
 const path = require("path");
 const unzipper = require("unzipper");
@@ -14,34 +14,34 @@ fileMetaInformationVersionArray[1] = 1;
 
 const metadata = {
   "00020001": {
-      "Value": [
-        fileMetaInformationVersionArray.buffer
-      ],
-      "vr": "OB"
+    "Value": [
+      fileMetaInformationVersionArray.buffer
+    ],
+    "vr": "OB"
   },
   "00020012": {
-      "Value": [
-          "1.2.840.113819.7.1.1997.1.0"
-      ],
-      "vr": "UI"
+    "Value": [
+      "1.2.840.113819.7.1.1997.1.0"
+    ],
+    "vr": "UI"
   },
   "00020002": {
-      "Value": [
-          "1.2.840.10008.5.1.4.1.1.4"
-      ],
-      "vr": "UI"
+    "Value": [
+      "1.2.840.10008.5.1.4.1.1.4"
+    ],
+    "vr": "UI"
   },
   "00020003": {
-      "Value": [
-          DicomMetaDictionary.uid()
-      ],
-      "vr": "UI"
+    "Value": [
+      DicomMetaDictionary.uid()
+    ],
+    "vr": "UI"
   },
   "00020010": {
-      "Value": [
-          "1.2.840.10008.1.2"
-      ],
-      "vr": "UI"
+    "Value": [
+      "1.2.840.10008.1.2"
+    ],
+    "vr": "UI"
   }
 };
 
@@ -74,7 +74,7 @@ const sequenceMetadata = {
 }
 
 function downloadToFile(url, filePath) {
-  return new Promise( (resolve,reject) => {
+  return new Promise((resolve, reject) => {
     const fileStream = fs.createWriteStream(filePath);
     const request = https.get(url, (response) => {
       response.pipe(fileStream);
@@ -152,9 +152,9 @@ const tests = {
     const unzipPath = path.join(os.tmpdir(), "test_multiframe_1");
 
     downloadToFile(url, zipFilePath)
-      .then( () => {
+      .then(() => {
         fs.createReadStream(zipFilePath)
-          .pipe(unzipper.Extract( {path: unzipPath} )
+          .pipe(unzipper.Extract({ path: unzipPath })
             .on('close', () => {
               const mrHeadPath = path.join(unzipPath, "MRHead");
               fs.readdir(mrHeadPath, (err, fileNames) => {
@@ -188,9 +188,9 @@ const tests = {
     const segFilePath = path.join(os.tmpdir(), "Lesion1_onesliceSEG.dcm");
 
     downloadToFile(ctPelvisURL, zipFilePath)
-      .then( () => {
+      .then(() => {
         fs.createReadStream(zipFilePath)
-          .pipe(unzipper.Extract( {path: unzipPath} )
+          .pipe(unzipper.Extract({ path: unzipPath })
             .on('close', () => {
               const ctPelvisPath = path.join(unzipPath, "Series-1.2.840.113704.1.111.1916.1223562191.15");
               fs.readdir(ctPelvisPath, (err, fileNames) => {
@@ -211,7 +211,7 @@ const tests = {
                 expect(roundedSpacing).to.equal(5);
 
                 downloadToFile(segURL, segFilePath)
-                  .then( () => {
+                  .then(() => {
                     const arrayBuffer = fs.readFileSync(segFilePath).buffer;
                     const dicomDict = DicomMessage.readFile(arrayBuffer);
                     const dataset = DicomMetaDictionary.naturalizeDataset(dicomDict.dict);
@@ -225,6 +225,18 @@ const tests = {
           );
       });
   },
+
+  test_multiframe_us: () => {
+    const file = fs.readFileSync(path.join(__dirname, 'cine-test.dcm'));
+    const dicomData = dcmjs.data.DicomMessage.readFile(file.buffer, {
+      // ignoreErrors: true,
+    });
+    const dataset = dcmjs.data.DicomMetaDictionary.naturalizeDataset(dicomData.dict);
+    // eslint-disable-next-line no-underscore-dangle
+    dataset._meta = dcmjs.data.DicomMetaDictionary.namifyDataset(dicomData.meta);
+    expect(dataset.NumberOfFrames).to.equal(117);
+    console.log("Finished test_multiframe_us")
+  }
 }
 
 


### PR DESCRIPTION
- Use offset table for reading fragments if present, otherwise, loop until end of stream/sequence

Issue I was seeing was with a multiframe US instance with no offset table (length == 0), and dcmjs would then assume there were no frames. This changes that behavior to go ahead and try to parse the pixel data sequence, which is what dicomParser does.

- Add option to not fragment encapsulated pixel data (use fragments equal to frame size)

Discussion with others on the open source imaging zoom call seemed to suggest that pixel data fragmentation is partly an artifact of older machines that could not buffer entire large instances in memory. This adds an option not to fragment when writing encapsulated pixel data, which in my brief tests seems to be a lot faster for large cine instances.