### PR TITLE
Add pattern matching for running one test from command line

### DIFF
--- a/test/test_data.js
+++ b/test/test_data.js
@@ -228,10 +228,15 @@ const tests = {
 }
 
 
-exports.test = async () => {
+exports.test = async (testToRun) => {
   Object.keys(tests).forEach(testName => {
+    if (testToRun && !testName.toLowerCase().includes(testToRun.toLowerCase())) {
+      console.log("-- Skipping " + testName);
+      return false;
+    }
     console.log("-- Starting " + testName);
     tests[testName]();
   });
 }
 
+exports.tests = tests;

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,8 +3,10 @@ const dcmjs = require('../build/dcmjs');
 
 expect(dcmjs).to.be.an('Object');
 
+const testToRun = process.argv[2];
+
 const parts = [
-  "DICOMWEB", "adapters", "data", "derivations", 
+  "DICOMWEB", "adapters", "data", "derivations",
   "normalizers", "sr", "utilities",
 ];
 
@@ -17,9 +19,9 @@ parts.forEach(part => {
   expect(dcmjs).to.have.property(part);
 
   console.log("");
-  console.log("***** Testing "+part+" *****");
+  console.log("***** Testing " + part + " *****");
   console.log("");
 
-  const partTest = require("./test_"+part+".js");
-  partTest.test();
+  const partTest = require("./test_" + part + ".js");
+  partTest.test(testToRun);
 });


### PR DESCRIPTION
This lets you easily run just a subset of the tests, using a simple pattern:

`npm run test [pattern]` will only run tests that contain `[pattern]` in the name, not case sensitive. Helpful for development.