### PR TITLE
Add ability to parse `untilTag` and to `stopAfterTag` with namified or Group,Element syntax

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -32,9 +32,29 @@ const encapsulatedSyntaxes = [
 class DicomMessage {
     static read(bufferStream, syntax, ignoreErrors) {
         var dict = {};
+        var untilTagNormalized = Tag.fromDirtyString(untilTag);
+        var stopAfterTagNormalized = Tag.fromDirtyString(stopAfterTag);
+
         try {
             while (!bufferStream.end()) {
-                var readInfo = DicomMessage.readTag(bufferStream, syntax);
+                if (breakOnNextLoop === true) {
+                    break;
+                }
+                const readInfo = DicomMessage.readTag(bufferStream, syntax);
+                const cleanTagString = readInfo.tag.toCleanString();
+
+                if (
+                    untilTagNormalized &&
+                    untilTagNormalized.toCleanString() === cleanTagString
+                ) {
+                    break;
+                }
+                if (
+                    stopAfterTagNormalized &&
+                    stopAfterTagNormalized.toCleanString() === cleanTagString
+                ) {
+                    breakOnNextLoop = true;
+                }
 
                 dict[readInfo.tag.toCleanString()] = {
                     vr: readInfo.vr.type,

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -2,6 +2,7 @@ import { paddingLeft } from "./ValueRepresentation.js";
 import { ValueRepresentation } from "./ValueRepresentation.js";
 import { DicomMessage } from "./DicomMessage.js";
 import { WriteBufferStream } from "./BufferStream.js";
+import { findByName } from "./dictionary.js";
 
 var IMPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2";
 var EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1";
@@ -62,6 +63,37 @@ class Tag {
 
     isPixelDataTag() {
         return this.is(0x7fe00010);
+    }
+
+    static fromDirtyString(str) {
+        if (!str || str.length < 1) {
+            return null;
+        }
+        /**
+         * Check first for Group,Element format.
+         *
+         * Matches various formats for string representation of tags:
+         * (0028,7017)
+         * [0028,7017]
+         * 0028,7017
+         * 00287017
+         * x00287017
+         */
+        const matcher = /^x?[\[\(]?([A-Z0-9]{4}),?([A-Z0-9]{4})[\)\]]?$/;
+        const matches = str.match(matcher);
+        if (matches && matches.length > 2) {
+            // For given string (0028,7017), should return array like: ["(0028,7017)", "0028", "7017"]
+            return Tag.fromString(matches[1] + matches[2]);
+        } else {
+            /**
+             * If no match on Group,Element try to match on dictionary name.
+             */
+            const match = findByName(str);
+            if (match) {
+                return Tag.fromPString(match.tag);
+            }
+        }
+        return null;
     }
 
     static fromString(str) {

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -48060,3 +48060,12 @@ const dictionary = {
 };
 
 export default dictionary;
+export function findByName(tagName) {
+    const keys = Object.keys(dictionary);
+    for (let i = 0; i < keys.length; i += 1) {
+        if (dictionary[keys[i]].name === tagName) {
+            return dictionary[keys[i]];
+        }
+    }
+    return null;
+}


### PR DESCRIPTION
Adds `DicomMessage.readFile()` options `untilTag` and `stopAfterTag` that terminate parsing and return the so far parsed data either up to or including the given tag. Adds normalization of namified or group,element type tags.

Use:
```js
dicomData = dcmjs.data.DicomMessage.readFile(part10Buffer, {
    untilTag: 'StudyInstanceUID', // OR
    untilTag: '(0020,000D)', // OR
    stopAfterTag: 'PatientName', // OR
    stopAfterTag: 'x00100010', // etc...
});
```
Group,Element formats parsed:
```
(0028,7017)
[0028,7017]
0028,7017
00287017
x00287017
```