### PR TITLE
fix: 🐛 When converting to multiframe, fix IPP issues

### DIFF
--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -262,12 +262,12 @@ class ImageNormalizer extends Normalizer {
 
         // copy over each datasets window/level into the per-frame groups
         // and set the referenced series uid
-        this.datasets.forEach(function(dataset, datasetIndex) {
+        distanceDatasetPairs.forEach(function(pair) {
+            const dataset = pair[1];
+
             ds.PerFrameFunctionalGroupsSequence.push({
                 PlanePositionSequence: {
-                    ImagePositionPatient:
-                        distanceDatasetPairs[datasetIndex][1]
-                            .ImagePositionPatient
+                    ImagePositionPatient: dataset.ImagePositionPatient
                 },
                 FrameVOILUTSequence: {
                     WindowCenter: dataset.WindowCenter,


### PR DESCRIPTION
If datasets aren't already in order, the datasets where getting sorted then given the unsorted IPP. This if now fixed.