### PR TITLE
feat add generate segmentation from dataset

### DIFF
--- a/src/adapters/Cornerstone/Segmentation.js
+++ b/src/adapters/Cornerstone/Segmentation.js
@@ -108,3 +108,30 @@ function fillSegmentation(
         `No generateSegmentation adapater for cornerstone version ${cornerstoneToolsVersion}, exiting.`
     );
 }
+
+/**
+ * generateSegmentationWithDataset - Fills a derived segmentation dataset with cornerstoneTools `LabelMap3D` data from Dataset instead of images
+ *
+ * @param  {object[]} dataset An empty segmentation derived dataset.
+ * @param  {Object|Object[]} inputLabelmaps3D The cornerstone `Labelmap3D` object, or an array of objects.
+ * @param  {Object} userOptions Options object to override default options.
+ * @returns {Blob}           description
+ */
+function generateSegmentationWithDataset(
+    dataset,
+    inputLabelmaps3D,
+    options = { includeSliceSpacing: true },
+    cornerstoneToolsVersion = 4
+) {
+    if (cornerstoneToolsVersion === 4) {
+        return Segmentation_4X.generateSegmentationWithDataset(
+            dataset,
+            inputLabelmaps3D,
+            options
+        );
+    }
+
+    console.warn(
+        `No generateSegmentationWithDataset adapater for cornerstone version ${cornerstoneToolsVersion}, exiting.`
+    );
+}

--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -21,7 +21,8 @@ import {
 const Segmentation = {
     generateSegmentation,
     generateToolState,
-    fillSegmentation
+    fillSegmentation,
+    generateSegmentationWithDataset
 };
 
 export default Segmentation;
@@ -38,6 +39,29 @@ const generateSegmentationDefaultOptions = {
     includeSliceSpacing: true,
     rleEncode: true
 };
+
+/**
+ * generateSegmentationWithDataset - Generates cornerstoneTools brush data, given a stack of
+ * imageIds, images and the cornerstoneTools brushData.
+ *
+ * @param  {object[]} datasets An array of cornerstone image dataset that contain the metadata for each instance
+ *                             and a property _meta with empty array (required for compatibility with other dcmjs functions)
+ *                             The dataset for each instance of image can be generated with `cornerstone.metaData.get('instance', imageId)``
+ *                             but prop _meta = [] needs to be added to each element other
+ * @param  {Object|Object[]} inputLabelmaps3D The cornerstone `Labelmap3D` object, or an array of objects.
+ * @param  {Object} userOptions Options to pass to the segmentation derivation and `fillSegmentation`.
+ * @returns {Blob}
+ */
+function generateSegmentationWithDataset(
+    datasets,
+    inputLabelmaps3D,
+    userOptions = {}
+) {
+    //on multiframe images, datasets array contains only 1 element but should work as well
+    const multiframe = Normalizer.normalizeToDataset(datasets);
+    const segmentation = new SegmentationDerivation([multiframe], userOptions);
+    return fillSegmentation(segmentation, inputLabelmaps3D, userOptions);
+}
 
 /**
  * generateSegmentation - Generates cornerstoneTools brush data, given a stack of


### PR DESCRIPTION
In some cases cornerstone image loaders deprive _image object from **_data_** property, like reported here [#144](https://github.com/dcmjs-org/dcmjs/issues/144). The added function uses underlying dcmjs functionality but allow users to generate this dataset array themselves and use it to create the segmentation blob. 

Dataset array can be filled with `cornerstone.metaData.get('instance', imageId)` for each image int the series.

**Important:** each element in dataset needs a _meta property with empty array (` _meta=[] `) otherwise segmentation will be saved without any metadata