### PR TITLE
fix 

### DIFF
--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -262,9 +262,8 @@ class ImageNormalizer extends Normalizer {
 
         // copy over each datasets window/level into the per-frame groups
         // and set the referenced series uid
-        distanceDatasetPairs.forEach(function(pair) {
-            const dataset = pair[1];
-
+        // use unsorted dataset to maitain ordering sequence of ReferencedInstanceSequence with other sources (ex: segmentation labelmaps)
+        this.datasets.forEach(function(dataset) {
             ds.PerFrameFunctionalGroupsSequence.push({
                 PlanePositionSequence: {
                     ImagePositionPatient: dataset.ImagePositionPatient


### PR DESCRIPTION
Use unsorted dataset as source of ReferencedInstanceSequence in convertToMultiframe function to maintain ordering with other sources like segmentation labelMaps. 

as refered in [this](https://github.com/dcmjs-org/dcmjs/issues/144) discussion, when creating segmentation and using series with reversed order instances, the labelmaps will be out of sync with the instances. By using unsorted dataset as source of ReferencedInstanceSequence, ordering is maintained in all cases