### PR TITLE
fix improves the speed of writing bytes for an encapsulated multiframe image (#159)

### DIFF
--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -245,12 +245,24 @@ class BufferStream {
     }
 
     concat(stream) {
-        var newbuf = new ArrayBuffer(this.offset + stream.size),
-            int8 = new Uint8Array(newbuf);
-        int8.set(new Uint8Array(this.getBuffer(0, this.offset)));
-        int8.set(new Uint8Array(stream.getBuffer(0, stream.size)), this.offset);
-        this.buffer = newbuf;
-        this.view = new DataView(this.buffer);
+        var available = this.buffer.byteLength - this.offset;
+        if (stream.size > available) {
+            let newbuf = new ArrayBuffer(this.offset + stream.size);
+            let int8 = new Uint8Array(newbuf);
+            int8.set(new Uint8Array(this.getBuffer(0, this.offset)));
+            int8.set(
+                new Uint8Array(stream.getBuffer(0, stream.size)),
+                this.offset
+            );
+            this.buffer = newbuf;
+            this.view = new DataView(this.buffer);
+        } else {
+            let int8 = new Uint8Array(this.buffer);
+            int8.set(
+                new Uint8Array(stream.getBuffer(0, stream.size)),
+                this.offset
+            );
+        }
         this.offset += stream.size;
         this.size = this.offset;
         return this.buffer.byteLength;

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -250,8 +250,22 @@ class BinaryRepresentation extends ValueRepresentation {
                 frames = value.length,
                 startOffset = [];
 
+            // Calculate a total length for storing binary stream
+            var bufferLength = 0;
+            for (i = 0; i < frames; i++) {
+                bufferLength += value[i].byteLength;
+                let fragmentsLength = 1;
+                if (fragmentMultiframe) {
+                    fragmentsLength = Math.ceil(
+                        value[i].byteLength / fragmentSize
+                    );
+                }
+                // 8 bytes per fragment are needed to store 0xffff (2 bytes), 0xe000 (2 bytes), and frageStream size (4 bytes)
+                bufferLength += fragmentsLength * 8;
+            }
+
             binaryStream = new WriteBufferStream(
-                1024 * 1024 * 20,
+                bufferLength,
                 stream.isLittleEndian
             );
 

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -778,7 +778,7 @@ class SequenceOfItems extends ValueRepresentation {
         }
     }
 
-    writeBytes(stream, value, syntax) {
+    writeBytes(stream, value, syntax, writeOptions) {
         let written = 0;
 
         if (value) {
@@ -788,7 +788,12 @@ class SequenceOfItems extends ValueRepresentation {
                 super.write(stream, "Uint16", 0xe000);
                 super.write(stream, "Uint32", 0xffffffff);
 
-                written += DicomMessage.write(item, stream, syntax);
+                written += DicomMessage.write(
+                    item,
+                    stream,
+                    syntax,
+                    writeOptions
+                );
 
                 super.write(stream, "Uint16", 0xfffe);
                 super.write(stream, "Uint16", 0xe00d);


### PR DESCRIPTION
Hi, team,

This is to fix the issues #159: https://github.com/dcmjs-org/dcmjs/issues/159
It takes a lot of time (or the app crashes with heap out of bound) when writing bytes for an encapsulated multiframe images.

This is caused by too many BufferStream's "concat" method call to concatenate fragmented binary stream when dealing with a multiframe image, resulting in too many times of ArrayBuffer creation. This leads to O(n^2) on the memory (& time) complexity of writing DICOM data.

I tested with a sample image that has encapsulated pixel data and 120 frames:
https://oculusstoragestaging.blob.core.windows.net/error-testing/IM-0001-0010.dcm?sv=2019-12-12&st=2021-01-11T14%3A29%3A14Z&se=2021-02-11T14%3A29%3A00Z&sr=b&sp=r&sig=94kfZANKkjjd1q4GsgMaDkPG8vSEoHKTwQk6vG3A6s0%3D

Before this patch, it took 1,060 seconds.And after the patch, it only took 0.8 seconds with the same output.

If there is any question or anything to change, feel free to let me know.

Thank you so much