### PR TITLE
fix(seg): Use ReferencedSegmentNumber in shared FG

### DIFF
--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -660,9 +660,7 @@ function checkSEGsOverlapping(
             break;
         }
 
-        const segmentIndex =
-            PerFrameFunctionalGroups.SegmentIdentificationSequence
-                .ReferencedSegmentNumber;
+        const segmentIndex = getSegmentIndex(multiframe);
 
         let SourceImageSequence;
 
@@ -778,9 +776,7 @@ function insertOverlappingPixelDataPlanar(
             const PerFrameFunctionalGroups =
                 PerFrameFunctionalGroupsSequence[i];
 
-            const segmentIndex =
-                PerFrameFunctionalGroups.SegmentIdentificationSequence
-                    .ReferencedSegmentNumber;
+            const segmentIndex = getSegmentIndex(multiframe);
 
             if (segmentIndex !== segmentIndexToProcess) {
                 continue;
@@ -896,6 +892,18 @@ function insertOverlappingPixelDataPlanar(
     }
 }
 
+const getSegmentIndex = multiframe => {
+    const {
+        SharedFunctionalGroupsSequence,
+        PerFrameFunctionalGroupsSequence
+    } = multiframe;
+    return PerFrameFunctionalGroupsSequence.SegmentIdentificationSequence
+        ? PerFrameFunctionalGroupsSequence.SegmentIdentificationSequence
+              .ReferencedSegmentNumber
+        : SharedFunctionalGroupsSequence.SegmentIdentificationSequence
+              .ReferencedSegmentNumber;
+};
+
 function insertPixelDataPlanar(
     segmentsOnFrame,
     segmentsOnFrameArray,
@@ -951,9 +959,7 @@ function insertPixelDataPlanar(
             break;
         }
 
-        const segmentIndex =
-            PerFrameFunctionalGroups.SegmentIdentificationSequence
-                .ReferencedSegmentNumber;
+        const segmentIndex = getSegmentIndex(multiframe);
 
         let SourceImageSequence;
 


### PR DESCRIPTION
OHIF Issue: #2252

When ReferencedSegmentNumber IS available in the shared FG, and it does not need to be replicated in the per-frame FG. 
This code uses the shared value if no per-frame is available.