### PR TITLE
fix "require is not defined" issue in the browser #170

### DIFF
--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -17,14 +17,13 @@ import {
     encode,
     decode
 } from "../../utilities/compression/rleSingleSamplePerPixel";
+import cloneDeep from "lodash.clonedeep";
 
 const Segmentation = {
     generateSegmentation,
     generateToolState,
     fillSegmentation
 };
-
-const cloneDeep = require("lodash.clonedeep");
 
 export default Segmentation;
 


### PR DESCRIPTION
I just changed require to the import statement.

I didn't upgrade rollup this time. 
Rollup seems to have a breaking change in a newer version, but I'm not familiar with the library.
