### PR TITLE
fix(Segmentation): Cascade flag to skipOverlapping for generateToolState to the client

### DIFF
--- a/examples/displaySegmentation/index.html
+++ b/examples/displaySegmentation/index.html
@@ -61,9 +61,9 @@
         <script src="https://unpkg.com/cornerstone-wado-image-loader/dist/cornerstoneWADOImageLoader.min.js"></script>
         <script src="https://unpkg.com/hammerjs/hammer.min.js"></script>
 
-        <script src="/js/initCornerstone.js"></script>
+        <script src="../js/initCornerstone.js"></script>
 
-        <script src="/js/dcmjs.js"></script>
+        <script src="../js/dcmjs.js"></script>
 
         <script
             src="https://unpkg.com/react@16/umd/react.development.js"
@@ -123,13 +123,14 @@
                 const t0 = performance.now();
 
                 const {
-                    labelmapBuffer,
+                    labelmapBufferArray,
                     segMetadata,
                     segmentsOnFrame
                 } = dcmjs.adapters.Cornerstone.Segmentation.generateToolState(
                     imageIds,
                     arrayBuffer,
-                    cornerstone.metaData
+                    cornerstone.metaData,
+                    true
                 );
 
                 const t1 = performance.now();
@@ -140,7 +141,7 @@
 
                 setters.labelmap3DByFirstImageId(
                     imageIds[0],
-                    labelmapBuffer,
+                    labelmapBufferArray[0],
                     0,
                     segMetadata,
                     imageIds.length,

--- a/src/adapters/Cornerstone/Segmentation.js
+++ b/src/adapters/Cornerstone/Segmentation.js
@@ -59,13 +59,15 @@ function generateToolState(
     imageIds,
     arrayBuffer,
     metadataProvider,
+    skipOverlapping = false,
     cornerstoneToolsVersion = 4
 ) {
     if (cornerstoneToolsVersion === 4) {
         return Segmentation_4X.generateToolState(
             imageIds,
             arrayBuffer,
-            metadataProvider
+            metadataProvider,
+            skipOverlapping
         );
     }
 
@@ -73,7 +75,8 @@ function generateToolState(
         return Segmentation_3X.generateToolState(
             imageIds,
             arrayBuffer,
-            metadataProvider
+            metadataProvider,
+            skipOverlapping
         );
     }
 

--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -893,10 +893,10 @@ function insertOverlappingPixelDataPlanar(
 
 const getSegmentIndex = (multiframe, frame) => {
     const {
-        PerFrameFunctionalGroups,
-        SharedFunctionalGroupsSequence,
-        PerFrameFunctionalGroupsSequence
+        PerFrameFunctionalGroupsSequence,
+        SharedFunctionalGroupsSequence
     } = multiframe;
+    const PerFrameFunctionalGroups = PerFrameFunctionalGroupsSequence[frame];
     return PerFrameFunctionalGroups.SegmentIdentificationSequence
         ? PerFrameFunctionalGroups.SegmentIdentificationSequence
               .ReferencedSegmentNumber


### PR DESCRIPTION
This PR and the recent PR https://github.com/dcmjs-org/dcmjs/pull/183 by @igoroctaviano are the steps I needed to take to get the examples/displaySegmentation/index.html to work locally without errors. The rationale for the changes for this specific PR are explained in https://github.com/dcmjs-org/dcmjs/issues/184.

I'm not sure if lines 64 and 66 in displaySegmentation/index.html are necessary for the hosted netlify examples but I had to do that to test the example locally. I can remove those two lines if it's confirmed that they're unnecessary and would actually break the hosted example.