### PR TITLE
Added untilTag and includeUntilTagValue as an option for DICOM file reading

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -30,18 +30,29 @@ const encapsulatedSyntaxes = [
 ];
 
 class DicomMessage {
-    static read(bufferStream, syntax, ignoreErrors, untilTag=null, includeUntilTagValue=false) {
+    static read(
+        bufferStream,
+        syntax,
+        ignoreErrors,
+        untilTag = null,
+        includeUntilTagValue = false
+    ) {
         var dict = {};
         try {
             while (!bufferStream.end()) {
-                const readInfo = DicomMessage.readTag(bufferStream, syntax, untilTag, includeUntilTagValue);
+                const readInfo = DicomMessage.readTag(
+                    bufferStream,
+                    syntax,
+                    untilTag,
+                    includeUntilTagValue
+                );
                 const cleanTagString = readInfo.tag.toCleanString();
 
                 dict[cleanTagString] = {
                     vr: readInfo.vr.type,
                     Value: readInfo.values
                 };
-                
+
                 if (untilTag && untilTag === cleanTagString) {
                     break;
                 }
@@ -72,7 +83,14 @@ class DicomMessage {
         return encapsulatedSyntaxes.indexOf(syntax) != -1;
     }
 
-    static readFile(buffer, options = { ignoreErrors: false, untilTag: null , includeUntilTagValue: false}) {
+    static readFile(
+        buffer,
+        options = {
+            ignoreErrors: false,
+            untilTag: null,
+            includeUntilTagValue: false
+        }
+    ) {
         const { ignoreErrors, untilTag, includeUntilTagValue } = options;
         var stream = new ReadBufferStream(buffer),
             useSyntax = EXPLICIT_LITTLE_ENDIAN;
@@ -133,7 +151,12 @@ class DicomMessage {
         return written;
     }
 
-    static readTag(stream, syntax, untilTag=null, includeUntilTagValue=false) {
+    static readTag(
+        stream,
+        syntax,
+        untilTag = null,
+        includeUntilTagValue = false
+    ) {
         var implicit = syntax == IMPLICIT_LITTLE_ENDIAN ? true : false,
             isLittleEndian =
                 syntax == IMPLICIT_LITTLE_ENDIAN ||
@@ -147,9 +170,9 @@ class DicomMessage {
             element = stream.readUint16(),
             tag = tagFromNumbers(group, element);
 
-        if (untilTag === tag && untilTag !== null) {
-            if(!includeUntilTagValue) {
-                return { tag: tag, vr: null, values: null };
+        if (untilTag === tag.toCleanString() && untilTag !== null) {
+            if (!includeUntilTagValue) {
+                return { tag: tag, vr: 0, values: 0 };
             }
         }
 

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -30,16 +30,21 @@ const encapsulatedSyntaxes = [
 ];
 
 class DicomMessage {
-    static read(bufferStream, syntax, ignoreErrors) {
+    static read(bufferStream, syntax, ignoreErrors, untilTag=null, includeUntilTagValue=false) {
         var dict = {};
         try {
             while (!bufferStream.end()) {
-                var readInfo = DicomMessage.readTag(bufferStream, syntax);
+                const readInfo = DicomMessage.readTag(bufferStream, syntax, untilTag, includeUntilTagValue);
+                const cleanTagString = readInfo.tag.toCleanString();
 
-                dict[readInfo.tag.toCleanString()] = {
+                dict[cleanTagString] = {
                     vr: readInfo.vr.type,
                     Value: readInfo.values
                 };
+                
+                if (untilTag && untilTag === cleanTagString) {
+                    break;
+                }
             }
             return dict;
         } catch (err) {
@@ -67,8 +72,8 @@ class DicomMessage {
         return encapsulatedSyntaxes.indexOf(syntax) != -1;
     }
 
-    static readFile(buffer, options = { ignoreErrors: false }) {
-        const { ignoreErrors } = options;
+    static readFile(buffer, options = { ignoreErrors: false, untilTag: null , includeUntilTagValue: false}) {
+        const { ignoreErrors, untilTag, includeUntilTagValue } = options;
         var stream = new ReadBufferStream(buffer),
             useSyntax = EXPLICIT_LITTLE_ENDIAN;
         stream.reset();
@@ -86,7 +91,13 @@ class DicomMessage {
         //get the syntax
         var mainSyntax = metaHeader["00020010"].Value[0];
         mainSyntax = DicomMessage._normalizeSyntax(mainSyntax);
-        var objects = DicomMessage.read(stream, mainSyntax, ignoreErrors);
+        var objects = DicomMessage.read(
+            stream,
+            mainSyntax,
+            ignoreErrors,
+            untilTag,
+            includeUntilTagValue
+        );
 
         var dicomDict = new DicomDict(metaHeader);
         dicomDict.dict = objects;
@@ -122,7 +133,7 @@ class DicomMessage {
         return written;
     }
 
-    static readTag(stream, syntax) {
+    static readTag(stream, syntax, untilTag=null, includeUntilTagValue=false) {
         var implicit = syntax == IMPLICIT_LITTLE_ENDIAN ? true : false,
             isLittleEndian =
                 syntax == IMPLICIT_LITTLE_ENDIAN ||
@@ -135,6 +146,12 @@ class DicomMessage {
         var group = stream.readUint16(),
             element = stream.readUint16(),
             tag = tagFromNumbers(group, element);
+
+        if (untilTag === tag && untilTag !== null) {
+            if(!includeUntilTagValue) {
+                return { tag: tag, vr: null, values: null };
+            }
+        }
 
         var length = null,
             vr = null,

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -359,7 +359,35 @@ const tests = {
         function writeToBuffer(dicomDict, options) {
             return dicomDict.write(options);
         }
-    }
+    },
+    test_untiltag: () => {
+        const buffer = fs.readFileSync(
+            path.join(__dirname, 'sample-dicom.dcm')
+        );
+        console.time('readFile');
+        const fullData = DicomMessage.readFile(buffer.buffer)
+        console.timeEnd('readFile');
+
+        console.time('readFile without untilTag');
+        const dicomData = DicomMessage.readFile(buffer.buffer, options={ untilTag: '7FE00010', includeUntilTagValue: false });
+        console.timeEnd('readFile without untilTag');
+
+        console.time('readFile with untilTag');
+        const dicomData2 = DicomMessage.readFile(buffer.buffer, options={ untilTag: '7FE00010', includeUntilTagValue: true });
+        console.timeEnd('readFile with untilTag');
+
+        const full_dataset = DicomMetaDictionary.naturalizeDataset(fullData.dict);
+        full_dataset._meta = DicomMetaDictionary.namifyDataset(fullData.meta);
+
+        const dataset = DicomMetaDictionary.naturalizeDataset(dicomData.dict);
+        dataset._meta = DicomMetaDictionary.namifyDataset(dicomData.meta);
+
+        const dataset2 = DicomMetaDictionary.naturalizeDataset(dicomData2.dict);
+        dataset2._meta = DicomMetaDictionary.namifyDataset(dicomData2.meta);
+
+        expect(full_dataset.PixelData).to.deep.equal(dataset2.PixelData);
+        expect(dataset.PixelData).to.deep.equal(0);
+    },
 };
 
 exports.test = async testToRun => {

--- a/test/test_untilTag.js
+++ b/test/test_untilTag.js
@@ -1,8 +1,11 @@
+const expect = require("chai").expect;
 const fs = require('fs');
+const path = require("path")
 const dcmjs = require('../build/dcmjs.js')
 const buffer = fs.readFileSync('sample-dicom.dcm');
 
 const { DicomMessage, DicomMetaDictionary } = dcmjs.data;
+
 console.time('readFile');
 const fullData = DicomMessage.readFile(buffer.buffer)
 console.timeEnd('readFile');
@@ -18,14 +21,17 @@ console.timeEnd('readFile with untilTag');
 const full_dataset = DicomMetaDictionary.naturalizeDataset(fullData.dict);
 full_dataset._meta = DicomMetaDictionary.namifyDataset(fullData.meta);
 
-console.log(full_dataset.PixelData);
+// console.log(full_dataset.PixelData);
 
 const dataset = DicomMetaDictionary.naturalizeDataset(dicomData.dict);
 dataset._meta = DicomMetaDictionary.namifyDataset(dicomData.meta);
 
-console.log(dataset.PixelData);
+// console.log(dataset.PixelData);
 
 const dataset2 = DicomMetaDictionary.naturalizeDataset(dicomData2.dict);
 dataset2._meta = DicomMetaDictionary.namifyDataset(dicomData2.meta);
 
-console.log(dataset2.PixelData);
+// console.log(dataset2.PixelData);
+
+expect(full_dataset.PixelData).to.deep.equal(dataset2.PixelData);
+expect(dataset.PixelData).to.deep.equal(0);

--- a/test/test_untilTag.js
+++ b/test/test_untilTag.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const dcmjs = require('C:/Users/DHDESK/Desktop/dcmjs/dcmjs/build/dcmjs.js')
+const buffer = fs.readFileSync('sample-dicom.dcm');
+
+const { DicomMessage, DicomMetaDictionary } = dcmjs.data;
+console.time('readFile');
+const fullData = DicomMessage.readFile(buffer.buffer)
+console.timeEnd('readFile');
+
+console.time('readFile without untilTag');
+const dicomData = DicomMessage.readFile(buffer.buffer, options={ untilTag: '7FE00010', includeUntilTagValue: false });
+console.timeEnd('readFile without untilTag');
+
+console.time('readFile with untilTag');
+const dicomData2 = DicomMessage.readFile(buffer.buffer, options={ untilTag: '7FE00010', includeUntilTagValue: true });
+console.timeEnd('readFile with untilTag');
+
+const full_dataset = DicomMetaDictionary.naturalizeDataset(fullData.dict);
+full_dataset._meta = DicomMetaDictionary.namifyDataset(fullData.meta);
+
+console.log(full_dataset.PixelData);
+
+const dataset = DicomMetaDictionary.naturalizeDataset(dicomData.dict);
+dataset._meta = DicomMetaDictionary.namifyDataset(dicomData.meta);
+
+console.log(dataset.PixelData);
+
+const dataset2 = DicomMetaDictionary.naturalizeDataset(dicomData2.dict);
+dataset2._meta = DicomMetaDictionary.namifyDataset(dicomData2.meta);
+
+console.log(dataset2.PixelData);

--- a/test/test_untilTag.js
+++ b/test/test_untilTag.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const dcmjs = require('C:/Users/DHDESK/Desktop/dcmjs/dcmjs/build/dcmjs.js')
+const dcmjs = require('../build/dcmjs.js')
 const buffer = fs.readFileSync('sample-dicom.dcm');
 
 const { DicomMessage, DicomMetaDictionary } = dcmjs.data;


### PR DESCRIPTION
This pull request adds `untilTag` as a parameter for the `read`, `readTag`, and `readFile` functions so that the user can choose to ignore the rest of a DICOM file. A boolean flag `includeUntilTagValue` has also been added that returns the values of the given `untilTag` before ignoring the rest of the DICOM file.

PR has successfully run `npm test` and `npm run build`.

Related PR/Issues:
#134
#149 
#181 
