### PR TITLE
IDC-1215: Add hook to allow custom mapping of measurement group to Cornerstone tool class

### DIFF
--- a/src/adapters/Cornerstone/MeasurementReport.js
+++ b/src/adapters/Cornerstone/MeasurementReport.js
@@ -170,7 +170,14 @@ export default class MeasurementReport {
         return report;
     }
 
-    static generateToolState(dataset) {
+    /**
+     * Generate Cornerstone tool state from dataset
+     * @param {object} dataset dataset
+     * @param {object} hooks
+     * @param {object} hooks.getToolClass Function to map dataset to a tool class
+     * @returns
+     */
+    static generateToolState(dataset, hooks = {}) {
         // For now, bail out if the dataset is not a TID1500 SR with length measurements
         if (dataset.ContentTemplateSequence.TemplateIdentifier !== "1500") {
             throw new Error(
@@ -218,9 +225,17 @@ export default class MeasurementReport {
 
             const TrackingIdentifierValue = TrackingIdentifierGroup.TextValue;
 
-            const toolClass = registeredToolClasses.find(tc =>
-                tc.isValidCornerstoneTrackingIdentifier(TrackingIdentifierValue)
-            );
+            const toolClass = hooks.getToolClass
+                ? hooks.getToolClass(
+                      measurementGroup,
+                      dataset,
+                      registeredToolClasses
+                  )
+                : registeredToolClasses.find(tc =>
+                      tc.isValidCornerstoneTrackingIdentifier(
+                          TrackingIdentifierValue
+                      )
+                  );
 
             if (toolClass) {
                 const measurement = toolClass.getMeasurementData(


### PR DESCRIPTION
Add a new hook to allow other applications to define their own matching logic to map a measurement group to a Cornerstone tool class instead of purely relying on tracking identifiers.

- Opened PR (waiting for this merge): https://github.com/ImagingDataCommons/Viewers/pull/81
- Necessary for ticket (CCC annotations to Cornerstone): https://github.com/OHIF/Viewers/issues/1215
which allows the mapping from Crowds Cure Cancer uni and bidirectional annotations to Length and Bidirectional Cornerstone tool types.
- Datasets for uni directional: https://wiki.cancerimagingarchive.net/display/DOI/Crowds+Cure+Cancer%3A+Data+collected+at+the+RSNA+2017+annual+meeting
- Datasets for bi direictional: https://wiki.cancerimagingarchive.net/display/DOI/Crowds+Cure+Cancer%3A+Data+collected+at+the+RSNA+2018+annual+meeting