### PR TITLE
Fix: First pixel of a segment was omitted.

### DIFF
--- a/src/adapters/Cornerstone/Segmentation_4X.js
+++ b/src/adapters/Cornerstone/Segmentation_4X.js
@@ -1113,7 +1113,7 @@ function insertPixelDataPlanar(
         //
         for (let j = 0, len = alignedPixelDataI.data.length; j < len; ++j) {
             if (data[j]) {
-                for (let x = j + 1; x < len; ++x) {
+                for (let x = j; x < len; ++x) {
                     if (data[x]) {
                         labelmap2DView[x] = segmentIndex;
                     }


### PR DESCRIPTION
This PR proposes to fix a problem that causes the omission of the first pixel of every segment on frame. 

#### How to reproduce?
You could generate a segmentation with a square region,  when this segmentation is imported you should see a missing pixel in the top-left corner.