### PR TITLE
Make single item arrays into both array items the item value itself

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -142,8 +142,11 @@ class DicomMetaDictionary {
                 }
 
                 if (naturalDataset[naturalName].length === 1) {
-                    naturalDataset[naturalName] =
-                        naturalDataset[naturalName][0];
+                    const sqZero = naturalDataset[naturalName][0];
+                    naturalDataset[naturalName] = sqZero;
+                    if (sqZero && typeof sqZero === "object") {
+                        Object.assign(sqZero, [sqZero]);
+                    }
                 }
             }
         });

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -40,6 +40,7 @@ const metadata = {
 };
 
 const sequenceMetadata = {
+    "00080081": { "vr": "ST", "Value": [null] },
     "00081032": {
         vr: "SQ",
         Value: [
@@ -58,7 +59,26 @@ const sequenceMetadata = {
                 }
             }
         ]
-    }
+    },
+
+    "52009229": {
+        vr: "SQ",
+        Value: [
+            {
+                "00289110": {
+                    vr: "SQ",
+                    Value: [
+                        {
+                            "00180088": {
+                                vr: "DS",
+                                Value: [0.12],
+                            }
+                        }
+                    ],
+                },
+            },
+        ],
+    },
 };
 
 function downloadToFile(url, filePath) {
@@ -138,6 +158,14 @@ const tests = {
             "CodeValue",
             "IMG1332"
         );
+
+        const spacing = naturalSequence.SharedFunctionalGroupsSequence
+            .PixelMeasuresSequence.SpacingBetweenSlices;
+        const spacingIndexed = naturalSequence.SharedFunctionalGroupsSequence[0]
+            .PixelMeasuresSequence[0].SpacingBetweenSlices;
+        expect(spacing).to.equal(spacingIndexed);
+        expect(spacing).to.equal(0.12);
+
         expect(naturalSequence.ProcedureCodeSequence).to.have.property(
             "CodingSchemeDesignator",
             "L"


### PR DESCRIPTION
Single item sequences like Shared Functional Groups are very convenient to access as singleton items, but others like the per-item functional groups are typically accessed as a arrays, even when they have only a single item in them.  This change preserves the "arrayness" of the items even of single-item values, but also preserves the singleton items, so that it is possible to access either:
metadata.SharedFunctionalGroupsSequence[0]
and get the same value as:
metadata.SharedFunctionalGroupsSequence