### PR TITLE
fix(dcmjs): Remove a circular reference to the naturalize methods

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -143,9 +143,14 @@ class DicomMetaDictionary {
 
                 if (naturalDataset[naturalName].length === 1) {
                     const sqZero = naturalDataset[naturalName][0];
-                    naturalDataset[naturalName] = sqZero;
-                    if (sqZero && typeof sqZero === "object") {
-                        Object.assign(sqZero, [sqZero]);
+                    if (
+                        sqZero &&
+                        typeof sqZero === "object" &&
+                        !sqZero.length
+                    ) {
+                        Object.assign(naturalDataset[naturalName], sqZero);
+                    } else {
+                        naturalDataset[naturalName] = sqZero;
                     }
                 }
             }

--- a/test/test_data.js
+++ b/test/test_data.js
@@ -165,6 +165,7 @@ const tests = {
             .PixelMeasuresSequence[0].SpacingBetweenSlices;
         expect(spacing).to.equal(spacingIndexed);
         expect(spacing).to.equal(0.12);
+	expect(Array.isArray(naturalSequence.SharedFunctionGroupsSequence)).to.be(true);
 
         expect(naturalSequence.ProcedureCodeSequence).to.have.property(
             "CodingSchemeDesignator",


### PR DESCRIPTION
The previous version of the code generated circular references, which some people didn't like, and also the fix didn't create an "isArray" instance because:
a = {} 
Array.isArray(Object.assign(a,[a]))==false
but:
arrayOfA = [a]
Array.isArray(Object.assign(arrayOfA,a))===true
which makes the result iterable.
@rodolfo.costa@radicalimaging.com
