### PR TITLE
Invalid VR of the private creator tag of the "Implicit VR Endian" typed DICOM file (#241)

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -193,6 +193,8 @@ class DicomMessage {
                     vrType = "OW";
                 } else if (vrType == "xs") {
                     vrType = "US";
+                } else if (tag.isPrivateCreator()) {
+                    vrType = "LO";
                 } else {
                     vrType = "UN";
                 }

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -64,6 +64,12 @@ class Tag {
         return this.is(0x7fe00010);
     }
 
+    isPrivateCreator() {
+        const group = this.group();
+        const element = this.element();
+        return group % 2 === 1 && element < 0x100 && element > 0x00;
+    }
+
     static fromString(str) {
         var group = parseInt(str.substring(0, 4), 16),
             element = parseInt(str.substring(4), 16);
@@ -96,7 +102,8 @@ class Tag {
                 useSyntax == EXPLICIT_LITTLE_ENDIAN
                     ? true
                     : false,
-            isEncapsulated = this.isPixelDataTag() && DicomMessage.isEncapsulated(syntax);
+            isEncapsulated =
+                this.isPixelDataTag() && DicomMessage.isEncapsulated(syntax);
 
         var oldEndian = stream.isLittleEndian;
         stream.setEndian(isLittleEndian);


### PR DESCRIPTION
Currently, when the transfer syntax of a DICOM is Implicit VR Endian (1.2.840.10008.1.2), the VR of the private creator tag is set to "UN"

According to the DICOM spec, this should be set to "LO". https://dicom.nema.org/medical/dicom/current/output/html/part05.html#sect_7.8.1


