### PR TITLE
Feat/cs3d planar freehand sr

### DIFF
--- a/src/adapters/Cornerstone/MeasurementReport.js
+++ b/src/adapters/Cornerstone/MeasurementReport.js
@@ -238,6 +238,7 @@ export default class MeasurementReport {
         derivationSourceDataset._vrMap = _vrMap;
 
         const report = new StructuredReport([derivationSourceDataset]);
+
         const contentItem = MeasurementReport.contentItem(
             derivationSourceDataset
         );

--- a/src/adapters/Cornerstone3D/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone3D/ArrowAnnotate.js
@@ -4,44 +4,54 @@ import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 import CodingScheme from "./CodingScheme";
 
 const ARROW_ANNOTATE = "ArrowAnnotate";
-const trackingIdentifierTextValue = "Cornerstone3DTools@^0.1.0:ArrowAnnotate";
+const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${ARROW_ANNOTATE}`;
 
 const { codeValues, CodingSchemeDesignator } = CodingScheme;
 
 class ArrowAnnotate {
     constructor() {}
 
-    static getMeasurementData(MeasurementGroup, imageId, imageToWorldCoords) {
+    static getMeasurementData(
+        MeasurementGroup,
+        sopInstanceUIDToImageIdMap,
+        imageToWorldCoords,
+        metadata
+    ) {
         const {
             defaultState,
-            SCOORDGroup,
-            findingGroup
-        } = MeasurementReport.getSetupMeasurementData(MeasurementGroup);
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            ArrowAnnotate.toolType
+        );
 
-        const text = findingGroup.ConceptCodeSequence.CodeMeaning;
+        const referencedImageId =
+            defaultState.annotation.metadata.referencedImageId;
+
+        const text = defaultState.metadata.label;
 
         const { GraphicData } = SCOORDGroup;
 
         const worldCoords = [];
         for (let i = 0; i < GraphicData.length; i += 2) {
-            const point = imageToWorldCoords(imageId, [
+            const point = imageToWorldCoords(referencedImageId, [
                 GraphicData[i],
                 GraphicData[i + 1]
             ]);
             worldCoords.push(point);
         }
 
-        const state = {
-            ...defaultState,
-            toolType: ArrowAnnotate.toolType,
-            data: {
-                text,
-                handles: {
-                    points: [worldCoords[0], worldCoords[1]],
-                    activeHandleIndex: 0,
-                    textBox: {
-                        hasMoved: false
-                    }
+        const state = defaultState;
+
+        state.annotation.data = {
+            text,
+            handles: {
+                points: [worldCoords[0], worldCoords[1]],
+                activeHandleIndex: 0,
+                textBox: {
+                    hasMoved: false
                 }
             }
         };
@@ -99,9 +109,9 @@ ArrowAnnotate.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
         return false;
     }
 
-    const [cornerstone4Tag, toolType] = TrackingIdentifier.split(":");
+    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
 
-    if (cornerstone4Tag !== CORNERSTONE_3D_TAG) {
+    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
         return false;
     }
 

--- a/src/adapters/Cornerstone3D/Length.js
+++ b/src/adapters/Cornerstone3D/Length.js
@@ -5,45 +5,55 @@ import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 const LENGTH = "Length";
 const FINDING = "121071";
 const FINDING_SITE = "G-C0E3";
-const trackingIdentifierTextValue = "Cornerstone3DTools@^0.1.0:Length";
+const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${LENGTH}`;
 
 class Length {
     constructor() {}
 
     // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
-    static getMeasurementData(MeasurementGroup, imageId, imageToWorldCoords) {
+    static getMeasurementData(
+        MeasurementGroup,
+        sopInstanceUIDToImageIdMap,
+        imageToWorldCoords,
+        metadata
+    ) {
         const {
             defaultState,
             NUMGroup,
             SCOORDGroup
-        } = MeasurementReport.getSetupMeasurementData(MeasurementGroup);
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            Length.toolType
+        );
+
+        const referencedImageId =
+            defaultState.annotation.metadata.referencedImageId;
 
         const { GraphicData } = SCOORDGroup;
         const worldCoords = [];
         for (let i = 0; i < GraphicData.length; i += 2) {
-            const point = imageToWorldCoords(imageId, [
+            const point = imageToWorldCoords(referencedImageId, [
                 GraphicData[i],
                 GraphicData[i + 1]
             ]);
             worldCoords.push(point);
         }
 
-        const state = {
-            ...defaultState,
-            length: NUMGroup.MeasuredValueSequence.NumericValue,
-            toolType: Length.toolType,
-            data: {
-                handles: {
-                    points: [worldCoords[0], worldCoords[1]],
-                    activeHandleIndex: 0,
-                    textBox: {
-                        hasMoved: false
-                    }
-                },
-                cachedStats: {
-                    [`imageId:${imageId}`]: {
-                        length: NUMGroup.MeasuredValueSequence.NumericValue
-                    }
+        const state = defaultState;
+
+        state.annotation.data = {
+            handles: {
+                points: [worldCoords[0], worldCoords[1]],
+                activeHandleIndex: 0,
+                textBox: {
+                    hasMoved: false
+                }
+            },
+            cachedStats: {
+                [`imageId:${referencedImageId}`]: {
+                    length: NUMGroup.MeasuredValueSequence.NumericValue
                 }
             }
         };
@@ -90,9 +100,9 @@ Length.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
         return false;
     }
 
-    const [cornerstone4Tag, toolType] = TrackingIdentifier.split(":");
+    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
 
-    if (cornerstone4Tag !== CORNERSTONE_3D_TAG) {
+    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
         return false;
     }
 

--- a/src/adapters/Cornerstone3D/MeasurementReport.js
+++ b/src/adapters/Cornerstone3D/MeasurementReport.js
@@ -316,8 +316,6 @@ export default class MeasurementReport {
             { sopInstanceUIDsToSeriesInstanceUIDMap }
         );
 
-        debugger;
-
         // Merge the derived dataset with the content from the Measurement Report
         report.dataset = Object.assign(report.dataset, contentItem);
         report.dataset._meta = _meta;

--- a/src/adapters/Cornerstone3D/MeasurementReport.js
+++ b/src/adapters/Cornerstone3D/MeasurementReport.js
@@ -3,6 +3,7 @@ import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
 import { StructuredReport } from "../../derivations/index.js";
 import TID1500MeasurementReport from "../../utilities/TID1500/TID1500MeasurementReport.js";
 import TID1501MeasurementGroup from "../../utilities/TID1500/TID1501MeasurementGroup.js";
+import Cornerstone3DCodingScheme from "./CodingScheme";
 
 import { toArray, codeMeaningEquals } from "../helpers.js";
 
@@ -80,15 +81,18 @@ export default class MeasurementReport {
     static getCornerstoneLabelFromDefaultState(defaultState) {
         const { findingSites = [], finding } = defaultState;
 
+        const cornersoneFreeTextCodingValue =
+            Cornerstone3DCodingScheme.codeValues.CORNERSTONEFREETEXT;
+
         let freeTextLabel = findingSites.find(
-            fs => fs.CodeValue === "CORNERSTONEFREETEXT"
+            fs => fs.CodeValue === cornersoneFreeTextCodingValue
         );
 
         if (freeTextLabel) {
             return freeTextLabel.CodeMeaning;
         }
 
-        if (finding && finding.CodeValue === "CORNERSTONEFREETEXT") {
+        if (finding && finding.CodeValue === cornersoneFreeTextCodingValue) {
             return finding.CodeMeaning;
         }
     }

--- a/src/adapters/Cornerstone3D/PlanarFreehandROI.js
+++ b/src/adapters/Cornerstone3D/PlanarFreehandROI.js
@@ -1,0 +1,141 @@
+import MeasurementReport from "./MeasurementReport";
+import TID300Polyline from "../../utilities/TID300/Polyline";
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
+import { vec3 } from "gl-matrix";
+
+const PLANARFREEHANDROI = "PlanarFreehandROI";
+const perimeterCodeValue = "131191004";
+const sctCodingSchemeDesignator = "SCT";
+const polylineGraphicType = "POLYLINE";
+const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${PLANARFREEHANDROI}`;
+const closedContourThreshold = 1e-5;
+
+class PlanarFreehandROI {
+    constructor() {}
+
+    static getMeasurementData(
+        MeasurementGroup,
+        sopInstanceUIDToImageIdMap,
+        imageToWorldCoords,
+        metadata
+    ) {
+        const {
+            defaultState,
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            PlanarFreehandROI.toolType
+        );
+
+        const referencedImageId =
+            defaultState.annotation.metadata.referencedImageId;
+        const { GraphicData } = SCOORDGroup;
+
+        const worldCoords = [];
+
+        for (let i = 0; i < GraphicData.length; i += 2) {
+            const point = imageToWorldCoords(referencedImageId, [
+                GraphicData[i],
+                GraphicData[i + 1]
+            ]);
+
+            worldCoords.push(point);
+        }
+
+        const distanceBetweenFirstAndLastPoint = vec3.distance(
+            worldCoords[worldCoords.length - 1],
+            worldCoords[0]
+        );
+
+        let isOpenContour = true;
+
+        // If the contour is closed, this should have been encoded as exactly the same point, so check for a very small difference.
+        if (distanceBetweenFirstAndLastPoint < closedContourThreshold) {
+            worldCoords.pop(); // Remove the last element which is duplicated.
+
+            isOpenContour = false;
+        }
+
+        let points = [];
+
+        if (isOpenContour) {
+            points.push(worldCoords[0], worldCoords[worldCoords.length - 1]);
+        }
+
+        const state = defaultState;
+
+        state.annotation.data = {
+            polyline: worldCoords,
+            isOpenContour,
+            handles: {
+                points,
+                activeHandleIndex: null,
+                textBox: {
+                    hasMoved: false
+                }
+            }
+        };
+
+        return state;
+    }
+
+    static getTID300RepresentationArguments(tool, worldToImageCoords) {
+        const { data, finding, findingSites, metadata } = tool;
+        const { isOpenContour, polyline } = data;
+
+        const { referencedImageId } = metadata;
+
+        if (!referencedImageId) {
+            throw new Error(
+                "PlanarFreehandROI.getTID300RepresentationArguments: referencedImageId is not defined"
+            );
+        }
+
+        const points = polyline.map(worldPos =>
+            worldToImageCoords(referencedImageId, worldPos)
+        );
+
+        if (!isOpenContour) {
+            // Need to repeat the first point at the end of to have an explicitly closed contour.
+            const lastPoint = points[points.length - 1];
+
+            // Explicitly expand to avoid ciruclar references.
+            points.push([lastPoint[0], lastPoint[1]]);
+        }
+
+        const area = 0; // TODO -> The tool doesn't have these stats yet.
+        const perimeter = 0;
+
+        return {
+            points,
+            area,
+            perimeter,
+            trackingIdentifierTextValue,
+            finding,
+            findingSites: findingSites || []
+        };
+    }
+}
+
+PlanarFreehandROI.toolType = PLANARFREEHANDROI;
+PlanarFreehandROI.utilityToolType = PLANARFREEHANDROI;
+PlanarFreehandROI.TID300Representation = TID300Polyline;
+PlanarFreehandROI.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+    if (!TrackingIdentifier.includes(":")) {
+        return false;
+    }
+
+    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+        return false;
+    }
+
+    return toolType === PLANARFREEHANDROI;
+};
+
+MeasurementReport.registerTool(PlanarFreehandROI);
+
+export default PlanarFreehandROI;

--- a/src/adapters/Cornerstone3D/Probe.js
+++ b/src/adapters/Cornerstone3D/Probe.js
@@ -1,0 +1,109 @@
+import MeasurementReport from "./MeasurementReport.js";
+import TID300Point from "../../utilities/TID300/Point.js";
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
+
+const PROBE = "Probe";
+const trackingIdentifierTextValue = `${CORNERSTONE_3D_TAG}:${PROBE}`;
+
+class Probe {
+    constructor() {}
+
+    static getMeasurementData(
+        MeasurementGroup,
+        sopInstanceUIDToImageIdMap,
+        imageToWorldCoords,
+        metadata
+    ) {
+        console.log("TODO");
+
+        const {
+            defaultState,
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            Probe.toolType
+        );
+
+        const referencedImageId =
+            defaultState.annotation.metadata.referencedImageId;
+
+        const { GraphicData } = SCOORDGroup;
+
+        const worldCoords = [];
+        for (let i = 0; i < GraphicData.length; i += 2) {
+            const point = imageToWorldCoords(referencedImageId, [
+                GraphicData[i],
+                GraphicData[i + 1]
+            ]);
+            worldCoords.push(point);
+        }
+
+        const state = defaultState;
+
+        state.annotation.data = {
+            handles: {
+                points: worldCoords,
+                activeHandleIndex: null,
+                textBox: {
+                    hasMoved: false
+                }
+            }
+        };
+
+        return state;
+    }
+
+    static getTID300RepresentationArguments(tool, worldToImageCoords) {
+        const { data, metadata } = tool;
+        let { finding, findingSites } = tool;
+        const { referencedImageId } = metadata;
+
+        if (!referencedImageId) {
+            throw new Error(
+                "Probe.getTID300RepresentationArguments: referencedImageId is not defined"
+            );
+        }
+
+        const { points } = data.handles;
+
+        const pointsImage = points.map(point => {
+            const pointImage = worldToImageCoords(referencedImageId, point);
+            return {
+                x: pointImage[0],
+                y: pointImage[1]
+            };
+        });
+
+        const TID300RepresentationArguments = {
+            points: pointsImage,
+            trackingIdentifierTextValue,
+            findingSites: findingSites || [],
+            finding
+        };
+
+        return TID300RepresentationArguments;
+    }
+}
+
+Probe.toolType = PROBE;
+Probe.utilityToolType = PROBE;
+Probe.TID300Representation = TID300Point;
+Probe.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
+    if (!TrackingIdentifier.includes(":")) {
+        return false;
+    }
+
+    const [cornerstone3DTag, toolType] = TrackingIdentifier.split(":");
+
+    if (cornerstone3DTag !== CORNERSTONE_3D_TAG) {
+        return false;
+    }
+
+    return toolType === PROBE;
+};
+
+MeasurementReport.registerTool(Probe);
+
+export default Probe;

--- a/src/adapters/Cornerstone3D/Probe.js
+++ b/src/adapters/Cornerstone3D/Probe.js
@@ -14,8 +14,6 @@ class Probe {
         imageToWorldCoords,
         metadata
     ) {
-        console.log("TODO");
-
         const {
             defaultState,
             SCOORDGroup

--- a/src/adapters/Cornerstone3D/index.js
+++ b/src/adapters/Cornerstone3D/index.js
@@ -3,6 +3,8 @@ import Length from "./Length.js";
 import Bidirectional from "./Bidirectional.js";
 import EllipticalROI from "./EllipticalROI.js";
 import ArrowAnnotate from "./ArrowAnnotate.js";
+import Probe from "./Probe.js";
+import PlanarFreehandROI from "./PlanarFreehandROI.js";
 import CodeScheme from "./CodingScheme";
 
 const Cornerstone3D = {
@@ -10,6 +12,8 @@ const Cornerstone3D = {
     Bidirectional,
     EllipticalROI,
     ArrowAnnotate,
+    Probe,
+    PlanarFreehandROI,
     MeasurementReport,
     CodeScheme
 };


### PR DESCRIPTION
In this PR I do multiple things:
- Overhaul the interface of the Cornerstone3D `MeasurementReport` adapter so that it is more natural and doesn't rely on extra knowledge of the system. The old interface you had to have some knowledge of the order of the annotations in the SR (i.e. you had to parse the SR before... parsing the SR) as there was an array of imageIds that are in an assumed order. Now you just pass in a map of sopInstanceUID to imageId.
- Allow for annotations to be from multiple referenced series in one SR. The correct references are made so that we reference each series correctly, rather than having all measurements incorrectly reference the first series of the first measurement (this is only done for the Cornerstone3D adapter, but effort has been put in to ensure that the old Cornerstone adapter still works as it did).
- Add read/write for Cornerstone3D annotations: planar freehand tool and probe tool.