### PR TITLE
fix: ArrowAnnotateTool adapter in Cornerstone3D parsing label

### DIFF
--- a/src/adapters/Cornerstone3D/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone3D/ArrowAnnotate.js
@@ -43,10 +43,8 @@ class ArrowAnnotate {
             worldCoords.push(point);
         }
 
-        // Since we use this adapter for both Cornerstone3D and Cornerstone legacy ArrowAnnotate,
-        // in the legacy code we don't store both start and end points. Therefore, if only one
-        // point is present, we derive the second point based on the image size relative to the
-        // first point.
+        // Since the arrowAnnotate measurement is just a point, to generate the tool state
+        // we derive the second point based on the image size relative to the first point.
         if (worldCoords.length === 1) {
             const imagePixelModule = metadata.get(
                 "imagePixelModule",
@@ -75,6 +73,7 @@ class ArrowAnnotate {
         state.annotation.data = {
             text,
             handles: {
+                arrowFirst: true,
                 points: [worldCoords[0], worldCoords[1]],
                 activeHandleIndex: 0,
                 textBox: {
@@ -97,18 +96,25 @@ class ArrowAnnotate {
             );
         }
 
-        const { points } = data.handles;
+        const { points, arrowFirst } = data.handles;
 
-        const pointsImage = points.map(point => {
-            const pointImage = worldToImageCoords(referencedImageId, point);
-            return {
-                x: pointImage[0],
-                y: pointImage[1]
-            };
-        });
+        let point;
+
+        if (arrowFirst) {
+            point = points[0];
+        } else {
+            point = points[1];
+        }
+
+        const pointImage = worldToImageCoords(referencedImageId, point);
 
         const TID300RepresentationArguments = {
-            points: pointsImage,
+            points: [
+                {
+                    x: pointImage[0],
+                    y: pointImage[1]
+                }
+            ],
             trackingIdentifierTextValue,
             findingSites: findingSites || []
         };

--- a/src/adapters/Cornerstone3D/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone3D/ArrowAnnotate.js
@@ -30,7 +30,7 @@ class ArrowAnnotate {
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
 
-        const text = defaultState.metadata.label;
+        const text = defaultState.annotation.metadata.label;
 
         const { GraphicData } = SCOORDGroup;
 
@@ -41,6 +41,33 @@ class ArrowAnnotate {
                 GraphicData[i + 1]
             ]);
             worldCoords.push(point);
+        }
+
+        // Since we use this adapter for both Cornerstone3D and Cornerstone legacy ArrowAnnotate,
+        // in the legacy code we don't store both start and end points. Therefore, if only one
+        // point is present, we derive the second point based on the image size relative to the
+        // first point.
+        if (worldCoords.length === 1) {
+            const imagePixelModule = metadata.get(
+                "imagePixelModule",
+                referencedImageId
+            );
+
+            let xOffset = 10;
+            let yOffset = 10;
+
+            if (imagePixelModule) {
+                const { columns, rows } = imagePixelModule;
+                xOffset = columns / 10;
+                yOffset = rows / 10;
+            }
+
+            const secondPoint = imageToWorldCoords(referencedImageId, [
+                GraphicData[0] + xOffset,
+                GraphicData[1] + yOffset
+            ]);
+
+            worldCoords.push(secondPoint);
         }
 
         const state = defaultState;

--- a/src/adapters/Cornerstone3D/EllipticalROI.js
+++ b/src/adapters/Cornerstone3D/EllipticalROI.js
@@ -196,7 +196,9 @@ EllipticalROI.isValidCornerstoneTrackingIdentifier = TrackingIdentifier => {
         return false;
     }
 
-    return toolType === ELLIPTICALROI;
+    // The following is needed since the new cornerstone3D has changed
+    // the EllipticalRoi toolName (which was in the old cornerstone) to EllipticalROI
+    return toolType.toLowerCase() === ELLIPTICALROI.toLowerCase();
 };
 
 MeasurementReport.registerTool(EllipticalROI);

--- a/src/adapters/Cornerstone3D/MeasurementReport.js
+++ b/src/adapters/Cornerstone3D/MeasurementReport.js
@@ -191,6 +191,7 @@ export default class MeasurementReport {
         });
 
         const defaultState = {
+            sopInstanceUid: ReferencedSOPInstanceUID,
             annotation: {
                 annotationUID: DicomMetaDictionary.uid(),
                 metadata: {

--- a/src/adapters/Cornerstone3D/index.js
+++ b/src/adapters/Cornerstone3D/index.js
@@ -6,6 +6,7 @@ import ArrowAnnotate from "./ArrowAnnotate.js";
 import Probe from "./Probe.js";
 import PlanarFreehandROI from "./PlanarFreehandROI.js";
 import CodeScheme from "./CodingScheme";
+import CORNERSTONE_3D_TAG from "./cornerstone3DTag";
 
 const Cornerstone3D = {
     Length,
@@ -15,7 +16,8 @@ const Cornerstone3D = {
     Probe,
     PlanarFreehandROI,
     MeasurementReport,
-    CodeScheme
+    CodeScheme,
+    CORNERSTONE_3D_TAG
 };
 
 export default Cornerstone3D;


### PR DESCRIPTION
- Expose constants for Cornerstone3D 
- Fix tool state generation for Arrow annotate
- Fix the Backward compatibility with legacy cornerstone for arrow