### PR TITLE
Fix erroneous point in dcmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcmjs",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Javascript implementation of DICOM manipulation",
   "main": "build/dcmjs.js",
   "module": "build/dcmjs.es.js",

--- a/src/adapters/Cornerstone3D/PlanarFreehandROI.js
+++ b/src/adapters/Cornerstone3D/PlanarFreehandROI.js
@@ -99,10 +99,10 @@ class PlanarFreehandROI {
 
         if (!isOpenContour) {
             // Need to repeat the first point at the end of to have an explicitly closed contour.
-            const lastPoint = points[points.length - 1];
+            const firstPoint = points[0];
 
             // Explicitly expand to avoid ciruclar references.
-            points.push([lastPoint[0], lastPoint[1]]);
+            points.push([firstPoint[0], firstPoint[1]]);
         }
 
         const area = 0; // TODO -> The tool doesn't have these stats yet.


### PR DESCRIPTION
Instead of pushing the first point again to encode a closed contour, we were pushing the last point again.