### PR TITLE
Fix errors parsing binary tags

### DIFF
--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -315,12 +315,10 @@ class BufferStream {
             throw new Error("Request more than currently allocated buffer");
         }
 
-        const newBuf = new ReadBufferStream(
-            this.buffer,
-            null,
-            this.offset,
-            this.offset + length
-        );
+        const newBuf = new ReadBufferStream(this.buffer, null, {
+            start: this.offset,
+            stop: this.offset + length
+        });
         this.increment(length);
 
         return newBuf;
@@ -341,10 +339,17 @@ class BufferStream {
 }
 
 class ReadBufferStream extends BufferStream {
-    constructor(buffer, littleEndian, start, end) {
+    constructor(
+        buffer,
+        littleEndian,
+        options = {
+            start: null,
+            stop: null
+        }
+    ) {
         super(buffer, littleEndian);
-        this.offset = start || 0;
-        this.size = end || this.buffer.byteLength;
+        this.offset = options.start || 0;
+        this.size = options.stop || this.buffer.byteLength;
         this.startOffset = this.offset;
         this.endOffset = this.size;
     }


### PR DESCRIPTION
Have run into a few bugs in the binary tag parsing on some DICOMs, and this PR contains fixes and test cases for those issues.

The two included DCM files are 13MB and 3MB - should these be hosted on GitHub releases like the other data is?

Details:

- Fix reading of OB tags with undefined length due to not handling trailing padding
- Fix reading of OB tags that use an offset table when there are large tags prior to the tag being read
- Make reading of sequence tags more explicit and add error checking
- Add two test cases for the above with DICOMs that previously had errors in parsing