### PR TITLE
Convert empty DecimalString and NumberString to null instead of zero

### DIFF
--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -534,15 +534,19 @@ class DecimalString extends StringRepresentation {
         if (ds.indexOf(BACKSLASH) !== -1) {
             // handle decimal string with multiplicity
             const dsArray = ds.split(BACKSLASH);
-            ds = dsArray.map(ds => Number(ds));
+            ds = dsArray.map(ds => (ds === "" ? null : Number(ds)));
         } else {
-            ds = [Number(ds)];
+            ds = [ds === "" ? null : Number(ds)];
         }
 
         return ds;
     }
 
     formatValue(value) {
+        if (value === null) {
+            return "";
+        }
+
         const str = String(value);
         if (str.length > this.maxLength) {
             return value.toExponential();
@@ -628,16 +632,22 @@ class IntegerString extends StringRepresentation {
         if (is.indexOf(BACKSLASH) !== -1) {
             // handle integer string with multiplicity
             const integerStringArray = is.split(BACKSLASH);
-            is = integerStringArray.map(is => Number(is));
+            is = integerStringArray.map(is => (is === "" ? null : Number(is)));
         } else {
-            is = [Number(is)];
+            is = [is === "" ? null : Number(is)];
         }
 
         return is;
     }
 
+    formatValue(value) {
+        return value === null ? "" : String(value);
+    }
+
     writeBytes(stream, value, writeOptions) {
-        const val = Array.isArray(value) ? value.map(String) : [value];
+        const val = Array.isArray(value)
+            ? value.map(is => this.formatValue(is))
+            : [this.formatValue(value)];
         return super.writeBytes(stream, val, writeOptions);
     }
 }

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -366,8 +366,8 @@ it("test_null_number_vrs", () => {
         dicomData.dict
     );
 
-    expect(dataset.ImageAndFluoroscopyAreaDoseProduct).toEqual(0);
-    expect(dataset.InstanceNumber).toEqual(0);
+    expect(dataset.ImageAndFluoroscopyAreaDoseProduct).toEqual(null);
+    expect(dataset.InstanceNumber).toEqual(null);
 });
 
 it("test_exponential_notation", () => {


### PR DESCRIPTION
This is needed when doing C-FIND with dcmjs-dimse, where "" means 'match everything', not zero.