### PR TITLE
Zero Copy ArrayBuffer

### DIFF
--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -50,7 +50,7 @@ function toFloat(val) {
 }
 
 class BufferStream {
-    constructor(sizeOrBuffer, littleEndian, view) {
+    constructor(sizeOrBuffer, littleEndian) {
         this.buffer =
             typeof sizeOrBuffer == "number"
                 ? new ArrayBuffer(sizeOrBuffer)
@@ -58,7 +58,7 @@ class BufferStream {
         if (!this.buffer) {
             this.buffer = new ArrayBuffer(0);
         }
-        this.view = view || new DataView(this.buffer);
+        this.view = new DataView(this.buffer);
         this.offset = 0;
         this.isLittleEndian = littleEndian || false;
         this.size = 0;
@@ -308,8 +308,7 @@ class BufferStream {
             this.buffer,
             null,
             this.offset,
-            this.offset + length,
-            this.view
+            this.offset + length
         );
         this.increment(length);
 
@@ -331,8 +330,8 @@ class BufferStream {
 }
 
 class ReadBufferStream extends BufferStream {
-    constructor(buffer, littleEndian, start, end, view) {
-        super(buffer, littleEndian, view);
+    constructor(buffer, littleEndian, start, end) {
+        super(buffer, littleEndian);
         this.offset = start || 0;
         this.size = end || this.buffer.byteLength;
         this.startOffset = this.offset;

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -24,6 +24,13 @@ function readTag(stream) {
     return tag;
 }
 
+function toWindows(inputArray, size) {
+    return Array.from(
+        { length: inputArray.length - (size - 1) }, //get the appropriate length
+        (_, index) => inputArray.slice(index, index + size) //create the windows
+    );
+}
+
 var binaryVRs = ["FL", "FD", "SL", "SS", "UL", "US", "AT"],
     explicitVRs = ["OB", "OW", "OF", "SQ", "UC", "UR", "UT", "UN"],
     singleVRs = ["SQ", "OF", "OW", "OB", "UN"];
@@ -342,6 +349,7 @@ class BinaryRepresentation extends ValueRepresentation {
         if (length == 0xffffffff) {
             var itemTagValue = Tag.readTag(stream),
                 frames = [];
+
             if (itemTagValue.is(0xfffee000)) {
                 var itemLength = stream.readUint32(),
                     numOfFrames = 1,
@@ -357,68 +365,73 @@ class BinaryRepresentation extends ValueRepresentation {
                     offsets = [];
                 }
 
+                const getFrameOrFragement = stream => {
+                    var nextTag = Tag.readTag(stream);
+                    if (!nextTag.is(0xfffee000)) {
+                        return [null, true];
+                    }
+                    let frameOrFragmentItemLength = stream.readUint32();
+                    const buffer = stream.getBuffer(
+                        stream.offset,
+                        stream.offset + frameOrFragmentItemLength
+                    );
+                    stream.increment(frameOrFragmentItemLength);
+                    return [buffer, false];
+                };
+
                 // If there is an offset table, use that to loop through pixel data sequence
-                // FIX: These two loops contain the exact same code, but I couldn't think of a way
-                // to combine the for and while loops non-confusingly so went with the explicit but
-                // redundant approach.
                 if (offsets.length > 0) {
+                    // make offsets relative to the stream, not tag
+                    offsets = offsets.map(e => e + stream.offset);
                     offsets.push(stream.size);
 
-                    for (var _i = 0; _i < offsets.length - 1; _i++) {
-                        let fragments = [];
-
-                        while (stream.offset < offsets[_i + 1]) {
-                            var nextTag = Tag.readTag(stream);
-
-                            if (!nextTag.is(0xfffee000)) {
+                    // window offsets to an array of [start,stop] locations
+                    frames = toWindows(offsets, 2).map(range => {
+                        const fragments = [];
+                        const [start, stop] = range;
+                        // create a new readable stream based on the range
+                        const s = new ReadBufferStream(
+                            stream.buffer,
+                            stream.littleEndian,
+                            start,
+                            stop,
+                            stream.view
+                        );
+                        while (!s.end()) {
+                            const [buf, done] = getFrameOrFragement(s);
+                            if (done) {
                                 break;
                             }
-
-                            let fragmentItemLength = stream.readUint32();
-
-                            fragments.push(stream.more(fragmentItemLength));
+                            fragments.push(buf);
                         }
+                        return fragments;
+                    });
 
-                        const frameSize = (() => {
-                            let size = 0;
-
-                            for (const fragment of fragments) {
-                                size += fragment.size;
-                            }
-
-                            return size;
-                        })();
-                        const frame = (() => {
-                            const frame = new Uint8Array(frameSize);
-                            let offset = 0;
-
-                            for (const fragment of fragments) {
-                                frame.set(
-                                    new Uint8Array(fragment.buffer),
-                                    offset
-                                );
-                                offset += fragment.size;
-                            }
-
-                            return frame;
-                        })();
-
-                        frames.push(frame.buffer);
-                    }
+                    frames = frames.map(fragments => {
+                        if (fragments.length < 1) {
+                            return fragments[0];
+                        } else {
+                            const frameSize = fragments.reduce(
+                                (size, buffer) => {
+                                    return size + buffer.byteLength;
+                                },
+                                0
+                            );
+                            const mergedFrame = new Uint8Array(frameSize);
+                            fragments.reduce((offset, buffer) => {
+                                mergedFrame.set(new Uint8Array(buffer), offset);
+                                return offset + buffer.byteLength;
+                            }, 0);
+                            return mergedFrame;
+                        }
+                    });
                 }
                 // If no offset table, loop through remainder of stream looking for termination tag
                 else {
                     while (stream.offset < stream.size) {
-                        const nextTag = Tag.readTag(stream);
-
-                        if (!nextTag.is(0xfffee000)) {
-                            break;
-                        }
-
-                        const frameItemLength = stream.readUint32();
-                        const fragmentStream = stream.more(frameItemLength);
-
-                        frames.push(fragmentStream.buffer);
+                        const [buffer, done] = getFrameOrFragement(stream);
+                        if (done) break;
+                        frames.push(buffer);
                     }
                 }
 
@@ -433,7 +446,6 @@ class BinaryRepresentation extends ValueRepresentation {
                     "Item tag not found after undefined binary length"
                 );
             }
-
             return frames;
         } else {
             var bytes;
@@ -442,7 +454,8 @@ class BinaryRepresentation extends ValueRepresentation {
             } else if (this.type == 'OB') {
                 bytes = stream.readUint8Array(length);
             }*/
-            bytes = stream.more(length).buffer;
+            bytes = stream.getBuffer(stream.offset, stream.offset + length);
+            stream.increment(length);
             return [bytes];
         }
     }

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -392,7 +392,7 @@ class BinaryRepresentation extends ValueRepresentation {
                         // create a new readable stream based on the range
                         const s = new ReadBufferStream(
                             stream.buffer,
-                            stream.littleEndian,
+                            stream.isLittleEndian,
                             start,
                             stop,
                             stream.view

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -394,8 +394,7 @@ class BinaryRepresentation extends ValueRepresentation {
                             stream.buffer,
                             stream.isLittleEndian,
                             start,
-                            stop,
-                            stream.view
+                            stop
                         );
                         while (!s.end()) {
                             const [buf, done] = getFrameOrFragement(s);


### PR DESCRIPTION
This PR changes the ReadBufferStream to not allocate new memory ArrayBuffers when calling `.more` The idea being that ReadBufferStreams can be treated as a "View" on top of some underlying ArrayBuffer sitting in memory.

 - It doesn't really change the speed performance.
 - I haven't done any memory profiling.

Thoughts? :+1: :-1: