### PR TITLE
more efficient buffer allocation

### DIFF
--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -249,7 +249,18 @@ class BufferStream {
     checkSize(step) {
         if (this.offset + step > this.buffer.byteLength) {
             //throw new Error("Writing exceeded the size of buffer");
-            //resize
+            //
+            // Resize the buffer.
+            // The idea is that when it is necessary to increase the buffer size,
+            // there will likely be more bytes which need to be written to the
+            // buffer in the future. Buffer allocation is costly.
+            // So we increase the buffer size right now
+            // by a larger amount than necessary, to reserve space for later
+            // writes which then can be done much faster. The current size of
+            // the buffer is the best estimate of the scale by which the size
+            // should increase.
+            // So approximately doubling the size of the buffer
+            // (while ensuring it fits the new data) is a simple but effective strategy.
             var dstSize = this.offset + step + this.buffer.byteLength;
             var dst = new ArrayBuffer(dstSize);
             new Uint8Array(dst).set(new Uint8Array(this.buffer));

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -250,7 +250,7 @@ class BufferStream {
         if (this.offset + step > this.buffer.byteLength) {
             //throw new Error("Writing exceeded the size of buffer");
             //resize
-            var dstSize = this.offset + step;
+            var dstSize = 2 * this.buffer.byteLength;
             var dst = new ArrayBuffer(dstSize);
             new Uint8Array(dst).set(new Uint8Array(this.buffer));
             this.buffer = dst;

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -250,7 +250,7 @@ class BufferStream {
         if (this.offset + step > this.buffer.byteLength) {
             //throw new Error("Writing exceeded the size of buffer");
             //resize
-            var dstSize = 2 * this.buffer.byteLength;
+            var dstSize = this.offset + step + this.buffer.byteLength;
             var dst = new ArrayBuffer(dstSize);
             new Uint8Array(dst).set(new Uint8Array(this.buffer));
             this.buffer = dst;


### PR DESCRIPTION
I was able to speed up writing segmentations for large series (>1000 images) by a factor of 10 in Firefox with this fix
The problem was too many buffer copies when the buffer was too small

The same strategy is used in Rust for vector capacity allocation: https://github.com/rust-lang/rust/blob/0ca7f74dbd23a3e8ec491cd3438f490a3ac22741/src/liballoc/raw_vec.rs#L397