### PR TITLE
feat: added metadata key to return

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -82,7 +82,11 @@ class DicomMessage {
 
                 dict[cleanTagString] = {
                     vr: readInfo.vr.type,
-                    Value: readInfo.values
+                    Value: readInfo.values,
+                    Meta: {
+                        length: readInfo.vr.length,
+                        type: readInfo.vr.type
+                    }
                 };
 
                 if (untilTag && untilTag === cleanTagString) {
@@ -263,8 +267,12 @@ class DicomMessage {
             }
         }
         stream.setEndian(oldEndian);
-
-        return { tag: tag, vr: vr, values: values };
+        vr.length = length;
+        return {
+            tag: tag,
+            vr: vr,
+            values: values
+        };
     }
 
     static lookupTag(tag) {

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -23,6 +23,7 @@ class ValueRepresentation {
     constructor(type) {
         this.type = type;
         this.multi = false;
+        this.length = undefined;
     }
 
     isBinary() {


### PR DESCRIPTION
Adding dcmjs to cornerstoneWADO requires knowledge of some metadata on a given tag. Current progress here: https://github.com/Ouwen/cornerstoneWADOImageLoader/tree/feat_added_dcmjs

Specifically replicating this line: https://github.com/Ouwen/cornerstoneWADOImageLoader/blob/939052f26d128d15e7d3edc4900984359b1da3ab/src/imageLoader/wadouri/getPixelData.js#L12

Which is determined if the pixel data tag is of a length `0xfffffff`