### PR TITLE
fix(imports): missing import for addAccessors

### DIFF
--- a/src/adapters/Cornerstone/MeasurementReport.js
+++ b/src/adapters/Cornerstone/MeasurementReport.js
@@ -3,6 +3,7 @@ import { DicomMetaDictionary } from "../../DicomMetaDictionary.js";
 import { StructuredReport } from "../../derivations/index.js";
 import TID1500MeasurementReport from "../../utilities/TID1500/TID1500MeasurementReport.js";
 import TID1501MeasurementGroup from "../../utilities/TID1500/TID1501MeasurementGroup.js";
+import addAccessors from "../../utilities/addAccessors.js";
 
 import { toArray, codeMeaningEquals } from "../helpers.js";
 

--- a/src/adapters/Cornerstone3D/MeasurementReport.js
+++ b/src/adapters/Cornerstone3D/MeasurementReport.js
@@ -4,6 +4,7 @@ import { StructuredReport } from "../../derivations/index.js";
 import TID1500MeasurementReport from "../../utilities/TID1500/TID1500MeasurementReport.js";
 import TID1501MeasurementGroup from "../../utilities/TID1500/TID1501MeasurementGroup.js";
 import Cornerstone3DCodingScheme from "./CodingScheme";
+import addAccessors from "../../utilities/addAccessors.js";
 
 import { toArray, codeMeaningEquals } from "../helpers.js";
 


### PR DESCRIPTION
For some reason (probably a force push) the imports for https://github.com/dcmjs-org/dcmjs/pull/274 was missing. I'm pretty sure I checked the PR and either was working for me or I fixed and pushed or not pushed. This is a fix for the missing import