### PR TITLE
fix: support a charset of "ISO_IR 6", and throw errors for unsupported encodings

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -11,6 +11,7 @@ const singleVRs = ["SQ", "OF", "OW", "OB", "UN", "LT"];
 
 const encodingMapping = {
     "iso-ir-192": "utf-8",
+    "iso-ir-6": "latin1",
     "": "latin1"
 };
 
@@ -91,11 +92,7 @@ class DicomMessage {
                         if (coding in encodingMapping) {
                             coding = encodingMapping[coding];
                         }
-                        try {
-                            bufferStream.setDecoder(new TextDecoder(coding));
-                        } catch (error) {
-                            console.warn(error);
-                        }
+                        bufferStream.setDecoder(new TextDecoder(coding));
                     }
                     if (readInfo.values.length > 1) {
                         console.warn(


### PR DESCRIPTION
This PR makes two changes:

- Make `ISO_IR 6` value for `SpecificCharacterEncoding` not `console.warn()` about an unsupported encoding.
- If the `SpecificCharacterEncoding` in a DICOM isn't supported by Node.js'`TextDecoder` then the error is now propagated and reading the DICOM will fail. The reason is that swallowing errors from unsupported encodings and proceeding seems like a dangerous/undesirable thing to do.