### PR TITLE
fix exceptions caused by undefined cached stats in adapters. Safe pro…

### DIFF
--- a/src/adapters/Cornerstone/CircleRoi.js
+++ b/src/adapters/Cornerstone/CircleRoi.js
@@ -12,8 +12,11 @@ class CircleRoi {
 
     /** Gets the measurement data for cornerstone, given DICOM SR measurement data. */
     static getMeasurementData(MeasurementGroup) {
-        const { defaultState, NUMGroup, SCOORDGroup } =
-            MeasurementReport.getSetupMeasurementData(MeasurementGroup);
+        const {
+            defaultState,
+            NUMGroup,
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(MeasurementGroup);
 
         const { GraphicData } = SCOORDGroup;
 
@@ -25,7 +28,9 @@ class CircleRoi {
             toolType: CircleRoi.toolType,
             active: false,
             cachedStats: {
-                area: NUMGroup.MeasuredValueSequence.NumericValue,
+                area: NUMGroup
+                    ? NUMGroup.MeasuredValueSequence.NumericValue
+                    : 0,
                 // Dummy values to be updated by cornerstone
                 radius: 0,
                 perimeter: 0
@@ -64,7 +69,7 @@ class CircleRoi {
      * @returns
      */
     static getTID300RepresentationArguments(tool) {
-        const { cachedStats, handles, finding, findingSites } = tool;
+        const { cachedStats = {}, handles, finding, findingSites } = tool;
         const { start: center, end } = handles;
         const { area, radius } = cachedStats;
 

--- a/src/adapters/Cornerstone/EllipticalRoi.js
+++ b/src/adapters/Cornerstone/EllipticalRoi.js
@@ -12,8 +12,11 @@ class EllipticalRoi {
 
     // TODO: this function is required for all Cornerstone Tool Adapters, since it is called by MeasurementReport.
     static getMeasurementData(MeasurementGroup) {
-        const { defaultState, NUMGroup, SCOORDGroup } =
-            MeasurementReport.getSetupMeasurementData(MeasurementGroup);
+        const {
+            defaultState,
+            NUMGroup,
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(MeasurementGroup);
 
         const { GraphicData } = SCOORDGroup;
 
@@ -56,7 +59,7 @@ class EllipticalRoi {
             toolType: EllipticalRoi.toolType,
             active: false,
             cachedStats: {
-                area: NUMGroup.MeasuredValueSequence.NumericValue
+                area: NUMGroup ? NUMGroup.MeasuredValueSequence.NumericValue : 0
             },
             handles: {
                 end: {
@@ -88,7 +91,7 @@ class EllipticalRoi {
     }
 
     static getTID300RepresentationArguments(tool) {
-        const { cachedStats, handles, finding, findingSites } = tool;
+        const { cachedStats = {}, handles, finding, findingSites } = tool;
         const { start, end } = handles;
         const { area } = cachedStats;
 

--- a/src/adapters/Cornerstone/FreehandRoi.js
+++ b/src/adapters/Cornerstone/FreehandRoi.js
@@ -6,8 +6,11 @@ class FreehandRoi {
     constructor() {}
 
     static getMeasurementData(MeasurementGroup) {
-        const { defaultState, SCOORDGroup } =
-            MeasurementReport.getSetupMeasurementData(MeasurementGroup);
+        const {
+            defaultState,
+            SCOORDGroup,
+            NUMGroup
+        } = MeasurementReport.getSetupMeasurementData(MeasurementGroup);
 
         const state = {
             ...defaultState,
@@ -22,6 +25,9 @@ class FreehandRoi {
                     allowedOutsideImage: true,
                     hasBoundingBox: true
                 }
+            },
+            cachedStats: {
+                area: NUMGroup ? NUMGroup.MeasuredValueSequence.NumericValue : 0
             },
             color: undefined,
             invalidated: true
@@ -38,7 +44,7 @@ class FreehandRoi {
     }
 
     static getTID300RepresentationArguments(/*tool*/) {
-        const { handles, finding, findingSites, cachedStats } = tool;
+        const { handles, finding, findingSites, cachedStats = {} } = tool;
         const { points } = handles;
         const { area = 0, perimeter = 0 } = cachedStats;
 

--- a/src/adapters/Cornerstone/RectangleRoi.js
+++ b/src/adapters/Cornerstone/RectangleRoi.js
@@ -6,8 +6,11 @@ class RectangleRoi {
     constructor() {}
 
     static getMeasurementData(MeasurementGroup) {
-        const { defaultState, SCOORDGroup } =
-            MeasurementReport.getSetupMeasurementData(MeasurementGroup);
+        const {
+            defaultState,
+            SCOORDGroup,
+            NUMGroup
+        } = MeasurementReport.getSetupMeasurementData(MeasurementGroup);
 
         const state = {
             ...defaultState,
@@ -24,6 +27,9 @@ class RectangleRoi {
                     hasBoundingBox: true
                 },
                 initialRotation: 0
+            },
+            cachedStats: {
+                area: NUMGroup ? NUMGroup.MeasuredValueSequence.NumericValue : 0
             },
             color: undefined,
             invalidated: true
@@ -43,7 +49,7 @@ class RectangleRoi {
     }
 
     static getTID300RepresentationArguments(tool) {
-        const { finding, findingSites, cachedStats, handles } = tool;
+        const { finding, findingSites, cachedStats = {}, handles } = tool;
         console.log("getTID300 Rectangle", tool, cachedStats, handles);
         const { start, end } = handles;
         const points = [

--- a/src/adapters/Cornerstone3D/Bidirectional.js
+++ b/src/adapters/Cornerstone3D/Bidirectional.js
@@ -88,7 +88,7 @@ class Bidirectional {
 
     static getTID300RepresentationArguments(tool, worldToImageCoords) {
         const { data, finding, findingSites, metadata } = tool;
-        const { cachedStats, handles } = data;
+        const { cachedStats = {}, handles } = data;
 
         const { referencedImageId } = metadata;
 
@@ -98,7 +98,8 @@ class Bidirectional {
             );
         }
 
-        const { length, width } = cachedStats[`imageId:${referencedImageId}`];
+        const { length, width } =
+            cachedStats[`imageId:${referencedImageId}`] || {};
         const { points } = handles;
 
         // Find the length and width point pairs by comparing the distances of the points at 0,1 to points at 2,3

--- a/src/adapters/Cornerstone3D/EllipticalROI.js
+++ b/src/adapters/Cornerstone3D/EllipticalROI.js
@@ -19,13 +19,16 @@ class EllipticalROI {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, NUMGroup, SCOORDGroup } =
-            MeasurementReport.getSetupMeasurementData(
-                MeasurementGroup,
-                sopInstanceUIDToImageIdMap,
-                metadata,
-                EllipticalROI.toolType
-            );
+        const {
+            defaultState,
+            NUMGroup,
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            EllipticalROI.toolType
+        );
 
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
@@ -119,7 +122,9 @@ class EllipticalROI {
             },
             cachedStats: {
                 [`imageId:${referencedImageId}`]: {
-                    area: NUMGroup.MeasuredValueSequence.NumericValue
+                    area: NUMGroup
+                        ? NUMGroup.MeasuredValueSequence.NumericValue
+                        : 0
                 }
             }
         };
@@ -129,7 +134,7 @@ class EllipticalROI {
 
     static getTID300RepresentationArguments(tool, worldToImageCoords) {
         const { data, finding, findingSites, metadata } = tool;
-        const { cachedStats, handles } = data;
+        const { cachedStats = {}, handles } = data;
 
         const { referencedImageId } = metadata;
 
@@ -167,7 +172,7 @@ class EllipticalROI {
             points.push({ x: bottom[0], y: bottom[1] });
         }
 
-        const { area } = cachedStats[`imageId:${referencedImageId}`];
+        const { area } = cachedStats[`imageId:${referencedImageId}`] || {};
 
         return {
             area,

--- a/src/adapters/Cornerstone3D/Length.js
+++ b/src/adapters/Cornerstone3D/Length.js
@@ -17,13 +17,16 @@ class Length {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, NUMGroup, SCOORDGroup } =
-            MeasurementReport.getSetupMeasurementData(
-                MeasurementGroup,
-                sopInstanceUIDToImageIdMap,
-                metadata,
-                Length.toolType
-            );
+        const {
+            defaultState,
+            NUMGroup,
+            SCOORDGroup
+        } = MeasurementReport.getSetupMeasurementData(
+            MeasurementGroup,
+            sopInstanceUIDToImageIdMap,
+            metadata,
+            Length.toolType
+        );
 
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
@@ -50,7 +53,9 @@ class Length {
             },
             cachedStats: {
                 [`imageId:${referencedImageId}`]: {
-                    length: NUMGroup.MeasuredValueSequence.NumericValue
+                    length: NUMGroup
+                        ? NUMGroup.MeasuredValueSequence.NumericValue
+                        : 0
                 }
             }
         };
@@ -60,7 +65,7 @@ class Length {
 
     static getTID300RepresentationArguments(tool, worldToImageCoords) {
         const { data, finding, findingSites, metadata } = tool;
-        const { cachedStats, handles } = data;
+        const { cachedStats = {}, handles } = data;
 
         const { referencedImageId } = metadata;
 
@@ -76,7 +81,8 @@ class Length {
         const point1 = { x: start[0], y: start[1] };
         const point2 = { x: end[0], y: end[1] };
 
-        const distance = cachedStats[`imageId:${referencedImageId}`].length;
+        const { length: distance } =
+            cachedStats[`imageId:${referencedImageId}`] || {};
 
         return {
             point1,


### PR DESCRIPTION
…gramming fix only

### Motivation
CachedStats property of annotation tools is populated async. So, to prevent JS exceptions when adapting report we should add some safe programming conditions.

###Includes
- Fix JS exception for adapting Tools (related to cachedStats)
- Safe programming only (no feature added)

fixes https://github.com/dcmjs-org/dcmjs/issues/302