### PR TITLE
fix: 🐛 relax condition in nearlyEquals check for detecting numbers near to zero

### DIFF
--- a/src/utilities/orientation/nearlyEqual.js
+++ b/src/utilities/orientation/nearlyEqual.js
@@ -18,10 +18,10 @@ export default function nearlyEqual(a, b, epsilon) {
     const absA = Math.abs(a);
     const absB = Math.abs(b);
     const diff = Math.abs(a - b);
-    if (a == b) {
+    if (a === b) {
         // shortcut, handles infinities
         return true;
-    } else if (a == 0 || b == 0 || absA + absB < Number.EPSILON) {
+    } else if (a === 0 || b === 0 || absA + absB < epsilon * epsilon) {
         // a or b is zero or both are extremely close to it
         // relative error is less meaningful here
         return diff < epsilon;

--- a/src/utilities/orientation/nearlyEqual.js
+++ b/src/utilities/orientation/nearlyEqual.js
@@ -2,12 +2,18 @@
  * nearlyEqual - Returns true if a and b are nearly equal
  * within a tolerance.
  *
- * This function logic source comes from:
+ * Inspiration for this function logic source comes from:
  * https://floating-point-gui.de/errors/comparison/
  *
  * https://floating-point-gui.de is published under
  * the Creative Commons Attribution License (BY):
  * http://creativecommons.org/licenses/by/3.0/
+ *
+ * The actual implementation has been adjusted 
+ * as discussed here: https://github.com/dcmjs-org/dcmjs/pull/304
+ *
+ * More information on floating point comparison here:
+ * http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
  *
  * @param {Number} a
  * @param {Number} b


### PR DESCRIPTION
Fix https://github.com/OHIF/Viewers/issues/2869, see https://github.com/OHIF/Viewers/issues/2869#issuecomment-1228331103 for more info