### PR TITLE
[FIX & TESTS] cleanTags : check if param is undefined. Add 3 test

### DIFF
--- a/src/anonymizer.js
+++ b/src/anonymizer.js
@@ -241,9 +241,15 @@ export function getTagsNameToEmpty() {
 
 export function cleanTags(
     dict,
-    tagNamesToReplace,
+    tagNamesToReplace = undefined,
     customTagNamesToEmpty = undefined
 ) {
+    if (tagNamesToReplace == undefined) {
+        tagNamesToReplace = {
+            "00100010": "ANON^PATIENT",
+            "00100020": "ANON^ID"
+        };
+    }
     var tags =
         customTagNamesToEmpty != undefined
             ? customTagNamesToEmpty

--- a/test/anonymizer.test.js
+++ b/test/anonymizer.test.js
@@ -2,7 +2,7 @@ import dcmjs from "../src/index.js";
 import fs from "fs";
 
 const { DicomMessage } = dcmjs.data;
-const { cleanTags } = dcmjs.anonymizer;
+const { cleanTags, getTagsNameToEmpty } = dcmjs.anonymizer;
 
 it("test_export", () => {
     expect(typeof cleanTags).toEqual("function");
@@ -27,4 +27,83 @@ it("test_anonymization", () => {
 
     // then
     expect(patientIDTag.Value).toEqual(["ANON^PATIENT"]);
+});
+
+it("test_anonymization_tagtoreplace_param", () => {
+    // given
+    const arrayBuffer = fs.readFileSync("test/sample-dicom.dcm").buffer;
+    const dicomDict = DicomMessage.readFile(arrayBuffer);
+
+    const tagInfo = dcmjs.data.DicomMetaDictionary.nameMap["PatientName"];
+    const tagNumber = tagInfo.tag,
+        tagString = dcmjs.data.Tag.fromPString(tagNumber).toCleanString();
+
+    const patientNameTag = dicomDict.dict[tagString];
+    const patientNameValue = patientNameTag.Value;
+
+    expect(patientNameValue).toEqual(["Fall 3"]);
+
+    var tagsToReplace = {
+        "00100010":   "REPLACE^PATIENT"
+    }
+    // when
+    cleanTags(dicomDict.dict, tagsToReplace);
+
+    // then
+    expect(patientNameTag.Value).toEqual(["REPLACE^PATIENT"]);
+});
+
+it("test_anonymization_keep_tag", () => {
+    // given
+    const arrayBuffer = fs.readFileSync("test/sample-dicom.dcm").buffer;
+    const dicomDict = DicomMessage.readFile(arrayBuffer);
+
+    const tagInfo = dcmjs.data.DicomMetaDictionary.nameMap["SeriesDescription"];
+    const tagNumber = tagInfo.tag,
+        tagString = dcmjs.data.Tag.fromPString(tagNumber).toCleanString();
+
+    const seriesDescriptionTag = dicomDict.dict[tagString];
+    const seriesDescriptionValue = seriesDescriptionTag.Value;
+
+    expect(seriesDescriptionValue).toEqual(["Oberbauch  *sSSH/FB/4mm"]);
+
+    var tagsToReplace = {};
+    var tagsToKeep = getTagsNameToEmpty();
+    var seriesDescription = "SeriesDescription";
+    if (tagsToKeep.indexOf(seriesDescription) != -1) {
+        tagsToKeep.splice(tagsToKeep.indexOf(seriesDescription), 1);
+    } 
+
+    // when
+    cleanTags(dicomDict.dict, tagsToReplace, tagsToKeep);
+
+    // then
+    expect(seriesDescriptionTag.Value).toEqual(["Oberbauch  *sSSH/FB/4mm"]);
+});
+
+it("test_anonymization_anonymize_tag", () => {
+    // given
+    const arrayBuffer = fs.readFileSync("test/sample-dicom.dcm").buffer;
+    const dicomDict = DicomMessage.readFile(arrayBuffer);
+
+    const tagInfo = dcmjs.data.DicomMetaDictionary.nameMap["SeriesInstanceUID"];
+    const tagNumber = tagInfo.tag,
+        tagString = dcmjs.data.Tag.fromPString(tagNumber).toCleanString();
+
+    const SeriesInstanceUIDTag = dicomDict.dict[tagString];
+    const SeriesInstanceUIDValue = SeriesInstanceUIDTag.Value;
+
+    expect(SeriesInstanceUIDValue).toEqual(["1.2.276.0.50.192168001092.11156604.14547392.303"]);
+
+    var tagsToReplace = {};
+    var tagsToAnon = getTagsNameToEmpty();
+    if (!tagsToAnon.includes("SeriesInstanceUID")) {
+        tagsToAnon.push("SeriesInstanceUID");
+    } 
+
+    // when
+    cleanTags(dicomDict.dict, tagsToReplace, tagsToAnon);
+
+    // then
+    expect(SeriesInstanceUIDTag.Value).toEqual([]);
 });


### PR DESCRIPTION
This PR fixes a test failure due to PR #303 
1. Check if a param is passed in function cleanTags. If not, create it and fill with default value.
It maintains backwards compatibility for the API.

2. Add 3 tests demonstrating the ways to use the method 

- force value for a specific tag. Usefull for pseudo-anonymization
- force a tag to be kept  => Remove it in the default array `tagNamesToEmpty`
- force a tag to be removed => Add it in the default array `tagNamesToEmpty`

