### PR TITLE
Resolves #316 Cornerstone3D adaptor - Multiframe support - add "frameNumber" to the Annotation.data

### DIFF
--- a/src/adapters/Cornerstone3D/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone3D/ArrowAnnotate.js
@@ -78,7 +78,7 @@ class ArrowAnnotate {
                     hasMoved: false
                 }
             },
-            frameNumber: ReferencedFrameNumber || 1,
+            frameNumber: ReferencedFrameNumber
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/ArrowAnnotate.js
+++ b/src/adapters/Cornerstone3D/ArrowAnnotate.js
@@ -17,7 +17,7 @@ class ArrowAnnotate {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, SCOORDGroup } =
+        const { defaultState, SCOORDGroup, ReferencedFrameNumber } =
             MeasurementReport.getSetupMeasurementData(
                 MeasurementGroup,
                 sopInstanceUIDToImageIdMap,
@@ -77,7 +77,8 @@ class ArrowAnnotate {
                 textBox: {
                     hasMoved: false
                 }
-            }
+            },
+            frameNumber: ReferencedFrameNumber || 1,
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/Bidirectional.js
+++ b/src/adapters/Cornerstone3D/Bidirectional.js
@@ -20,12 +20,13 @@ class Bidirectional {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, ReferencedFrameNumber } = MeasurementReport.getSetupMeasurementData(
-            MeasurementGroup,
-            sopInstanceUIDToImageIdMap,
-            metadata,
-            Bidirectional.toolType
-        );
+        const { defaultState, ReferencedFrameNumber } =
+            MeasurementReport.getSetupMeasurementData(
+                MeasurementGroup,
+                sopInstanceUIDToImageIdMap,
+                metadata,
+                Bidirectional.toolType
+            );
 
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
@@ -81,7 +82,7 @@ class Bidirectional {
                     width: shortAxisNUMGroup.MeasuredValueSequence.NumericValue
                 }
             },
-            frameNumber: ReferencedFrameNumber || 1,
+            frameNumber: ReferencedFrameNumber
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/Bidirectional.js
+++ b/src/adapters/Cornerstone3D/Bidirectional.js
@@ -20,7 +20,7 @@ class Bidirectional {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState } = MeasurementReport.getSetupMeasurementData(
+        const { defaultState, ReferencedFrameNumber } = MeasurementReport.getSetupMeasurementData(
             MeasurementGroup,
             sopInstanceUIDToImageIdMap,
             metadata,
@@ -80,7 +80,8 @@ class Bidirectional {
                     length: longAxisNUMGroup.MeasuredValueSequence.NumericValue,
                     width: shortAxisNUMGroup.MeasuredValueSequence.NumericValue
                 }
-            }
+            },
+            frameNumber: ReferencedFrameNumber || 1,
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/EllipticalROI.js
+++ b/src/adapters/Cornerstone3D/EllipticalROI.js
@@ -22,7 +22,8 @@ class EllipticalROI {
         const {
             defaultState,
             NUMGroup,
-            SCOORDGroup
+            SCOORDGroup,
+            ReferencedFrameNumber
         } = MeasurementReport.getSetupMeasurementData(
             MeasurementGroup,
             sopInstanceUIDToImageIdMap,
@@ -126,7 +127,8 @@ class EllipticalROI {
                         ? NUMGroup.MeasuredValueSequence.NumericValue
                         : 0
                 }
-            }
+            },
+            frameNumber: ReferencedFrameNumber || 1,
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/EllipticalROI.js
+++ b/src/adapters/Cornerstone3D/EllipticalROI.js
@@ -19,17 +19,13 @@ class EllipticalROI {
         imageToWorldCoords,
         metadata
     ) {
-        const {
-            defaultState,
-            NUMGroup,
-            SCOORDGroup,
-            ReferencedFrameNumber
-        } = MeasurementReport.getSetupMeasurementData(
-            MeasurementGroup,
-            sopInstanceUIDToImageIdMap,
-            metadata,
-            EllipticalROI.toolType
-        );
+        const { defaultState, NUMGroup, SCOORDGroup, ReferencedFrameNumber } =
+            MeasurementReport.getSetupMeasurementData(
+                MeasurementGroup,
+                sopInstanceUIDToImageIdMap,
+                metadata,
+                EllipticalROI.toolType
+            );
 
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
@@ -128,7 +124,7 @@ class EllipticalROI {
                         : 0
                 }
             },
-            frameNumber: ReferencedFrameNumber || 1,
+            frameNumber: ReferencedFrameNumber
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/Length.js
+++ b/src/adapters/Cornerstone3D/Length.js
@@ -20,7 +20,8 @@ class Length {
         const {
             defaultState,
             NUMGroup,
-            SCOORDGroup
+            SCOORDGroup,
+            ReferencedFrameNumber
         } = MeasurementReport.getSetupMeasurementData(
             MeasurementGroup,
             sopInstanceUIDToImageIdMap,
@@ -57,7 +58,8 @@ class Length {
                         ? NUMGroup.MeasuredValueSequence.NumericValue
                         : 0
                 }
-            }
+            },
+            frameNumber: ReferencedFrameNumber || 1,
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/Length.js
+++ b/src/adapters/Cornerstone3D/Length.js
@@ -17,17 +17,13 @@ class Length {
         imageToWorldCoords,
         metadata
     ) {
-        const {
-            defaultState,
-            NUMGroup,
-            SCOORDGroup,
-            ReferencedFrameNumber
-        } = MeasurementReport.getSetupMeasurementData(
-            MeasurementGroup,
-            sopInstanceUIDToImageIdMap,
-            metadata,
-            Length.toolType
-        );
+        const { defaultState, NUMGroup, SCOORDGroup, ReferencedFrameNumber } =
+            MeasurementReport.getSetupMeasurementData(
+                MeasurementGroup,
+                sopInstanceUIDToImageIdMap,
+                metadata,
+                Length.toolType
+            );
 
         const referencedImageId =
             defaultState.annotation.metadata.referencedImageId;
@@ -59,7 +55,7 @@ class Length {
                         : 0
                 }
             },
-            frameNumber: ReferencedFrameNumber || 1,
+            frameNumber: ReferencedFrameNumber
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/PlanarFreehandROI.js
+++ b/src/adapters/Cornerstone3D/PlanarFreehandROI.js
@@ -74,7 +74,7 @@ class PlanarFreehandROI {
                     hasMoved: false
                 }
             },
-            frameNumber: ReferencedFrameNumber || 1,
+            frameNumber: ReferencedFrameNumber
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/PlanarFreehandROI.js
+++ b/src/adapters/Cornerstone3D/PlanarFreehandROI.js
@@ -19,7 +19,7 @@ class PlanarFreehandROI {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, SCOORDGroup } =
+        const { defaultState, SCOORDGroup, ReferencedFrameNumber } =
             MeasurementReport.getSetupMeasurementData(
                 MeasurementGroup,
                 sopInstanceUIDToImageIdMap,
@@ -73,7 +73,8 @@ class PlanarFreehandROI {
                 textBox: {
                     hasMoved: false
                 }
-            }
+            },
+            frameNumber: ReferencedFrameNumber || 1,
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/Probe.js
+++ b/src/adapters/Cornerstone3D/Probe.js
@@ -46,7 +46,7 @@ class Probe {
                     hasMoved: false
                 }
             },
-            frameNumber: ReferencedFrameNumber || 1,
+            frameNumber: ReferencedFrameNumber
         };
 
         return state;

--- a/src/adapters/Cornerstone3D/Probe.js
+++ b/src/adapters/Cornerstone3D/Probe.js
@@ -14,7 +14,7 @@ class Probe {
         imageToWorldCoords,
         metadata
     ) {
-        const { defaultState, SCOORDGroup } =
+        const { defaultState, SCOORDGroup, ReferencedFrameNumber } =
             MeasurementReport.getSetupMeasurementData(
                 MeasurementGroup,
                 sopInstanceUIDToImageIdMap,
@@ -45,7 +45,8 @@ class Probe {
                 textBox: {
                     hasMoved: false
                 }
-            }
+            },
+            frameNumber: ReferencedFrameNumber || 1,
         };
 
         return state;


### PR DESCRIPTION
Cornerston3D's Annotation data type allows extending "data" field (key:value).

We are going to use the field to add "frameNumber" information to annotations.
This will help supporting multi-frame DICOM files on Cornerstone.