### PR TITLE
fix: check instance's NumberOfFrames property to see if it is a multi-frame file or not

### DIFF
--- a/src/adapters/Cornerstone3D/MeasurementReport.js
+++ b/src/adapters/Cornerstone3D/MeasurementReport.js
@@ -172,10 +172,8 @@ export default class MeasurementReport {
             group => group.ValueType === "SCOORD"
         );
         const { ReferencedSOPSequence } = SCOORDGroup.ContentSequence;
-        const {
-            ReferencedSOPInstanceUID,
-            ReferencedFrameNumber
-        } = ReferencedSOPSequence;
+        const { ReferencedSOPInstanceUID, ReferencedFrameNumber } =
+            ReferencedSOPSequence;
 
         const referencedImageId =
             sopInstanceUIDToImageIdMap[ReferencedSOPInstanceUID];
@@ -209,9 +207,8 @@ export default class MeasurementReport {
             defaultState.description = defaultState.finding.CodeMeaning;
         }
 
-        defaultState.annotation.metadata.label = MeasurementReport.getCornerstoneLabelFromDefaultState(
-            defaultState
-        );
+        defaultState.annotation.metadata.label =
+            MeasurementReport.getCornerstoneLabelFromDefaultState(defaultState);
 
         return {
             defaultState,
@@ -259,9 +256,8 @@ export default class MeasurementReport {
             const { sopInstanceUID, sopClassUID } = sopCommonModule;
             const { studyInstanceUID, seriesInstanceUID } = generalSeriesModule;
 
-            sopInstanceUIDsToSeriesInstanceUIDMap[
-                sopInstanceUID
-            ] = seriesInstanceUID;
+            sopInstanceUIDsToSeriesInstanceUIDMap[sopInstanceUID] =
+                seriesInstanceUID;
 
             if (
                 !derivationSourceDatasets.find(
@@ -269,10 +265,11 @@ export default class MeasurementReport {
                 )
             ) {
                 // Entry not present for series, create one.
-                const derivationSourceDataset = MeasurementReport.generateDerivationSourceDataset(
-                    studyInstanceUID,
-                    seriesInstanceUID
-                );
+                const derivationSourceDataset =
+                    MeasurementReport.generateDerivationSourceDataset(
+                        studyInstanceUID,
+                        seriesInstanceUID
+                    );
 
                 derivationSourceDatasets.push(derivationSourceDataset);
             }
@@ -286,7 +283,13 @@ export default class MeasurementReport {
                 ReferencedSOPInstanceUID: sopInstanceUID
             };
 
-            if (Normalizer.isMultiframeSOPClassUID(sopClassUID)) {
+            const instance = metadataProvider.get("instance", imageId);
+            if (
+                (instance &&
+                    instance.NumberOfFrames &&
+                    instance.NumberOfFrames > 1) ||
+                Normalizer.isMultiframeSOPClassUID(sopClassUID)
+            ) {
                 ReferencedSOPSequence.ReferencedFrameNumber = frameNumber;
             }
 
@@ -305,9 +308,8 @@ export default class MeasurementReport {
                 }
             });
 
-            allMeasurementGroups = allMeasurementGroups.concat(
-                measurementGroups
-            );
+            allMeasurementGroups =
+                allMeasurementGroups.concat(measurementGroups);
         });
 
         const tid1500MeasurementReport = new TID1500MeasurementReport(
@@ -382,11 +384,12 @@ export default class MeasurementReport {
                 measurementGroup.ContentSequence
             );
 
-            const TrackingIdentifierGroup = measurementGroupContentSequence.find(
-                contentItem =>
-                    contentItem.ConceptNameCodeSequence.CodeMeaning ===
-                    TRACKING_IDENTIFIER
-            );
+            const TrackingIdentifierGroup =
+                measurementGroupContentSequence.find(
+                    contentItem =>
+                        contentItem.ConceptNameCodeSequence.CodeMeaning ===
+                        TRACKING_IDENTIFIER
+                );
 
             const TrackingIdentifierValue = TrackingIdentifierGroup.TextValue;
 


### PR DESCRIPTION
### Cornerstone3D Adapter - support of multi-frame

It's difficult to add all the SOPClassUIDs that supports multi-frames.
So it's unrealistic to rely on checking SOPClassUID for multi-frames.

Here the code is checking Instance's NumberOfFrames attribute (the instance is fetched from metadataProvider.).

Line 286 ~ 292 is the actual change, and other changes are just caused by prettier.