### PR TITLE
Create Node version constraint at >= v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ _Parts of DICOM that dcmjs *will not* focus on:_
 
 ## In Node
 
+We aim to support at least the `Maintenance` version according to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule).
+
+At the moment, it should work with Node 11 and above (although it's not recommended to use End Of Life versions).
+
 ```None
 // To install latest _stable_ release
 npm install --save dcmjs

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "dcmjs",
   "version": "0.24.0",
   "description": "Javascript implementation of DICOM manipulation",
+  "engines" : {
+    "node" : ">=11.0.0"
+  },
+
   "main": "build/dcmjs.js",
   "module": "build/dcmjs.es.js",
   "directories": {


### PR DESCRIPTION
Should fix #319 
This change put a hard constraint on Node version number : npm should prevent users from installing if node version is under `v11` which is the first version that has `TextEncoder` in the global object like in the browser.
Changes in `package.json` set the node version constraint in the `engines` entry.
The `engine-strict` directive in the added `.npmrc` file should tell npm to enforce the constraint at npm install time.
I modified documentation accordingly.
Alternatively, we could just limit the constraint to a warning in the documentation and let users install at their own risk. 