### PR TITLE
Removed comment around getTID300RepresentationArguments 'tool' parameter

### DIFF
--- a/src/adapters/Cornerstone/FreehandRoi.js
+++ b/src/adapters/Cornerstone/FreehandRoi.js
@@ -43,7 +43,7 @@ class FreehandRoi {
         return state;
     }
 
-    static getTID300RepresentationArguments(/*tool*/) {
+    static getTID300RepresentationArguments(tool) {
         const { handles, finding, findingSites, cachedStats = {} } = tool;
         const { points } = handles;
         const { area = 0, perimeter = 0 } = cachedStats;


### PR DESCRIPTION
Fix for issue #306. Missing tests but since dcmjs seems to be missing a testing setup for adapters I think someone more familiar with js testing and dcmjs should set the standard.