### PR TITLE
fix(semantic): Indicate that the review name needs the semantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use the following "Commit Message Format" when drafting commit messages. If you'
 
 Note: Be wary of `BREAKING_CHANGE` in commit message descriptions, as this can force a major version bump.
 
-Be sure to use lower case for the first letter of your semantic commit message, so use `fix` not `Fix` or `feat` not `Feat`, and have a space after the :
+Be sure to use lower case for the first letter of your semantic commit message, so use `fix` not `Fix` or `feat` not `Feat`, have a space after the : and make the PR github review title follow the SAME rules.  It is the PR review title that determins the final commit message and will be used for semantic detection.
 
 Note: a new package version will be published only if the commit comes from a PR.
 


### PR DESCRIPTION
Arg - @pieper - still wasn't quite right, it looks like it tests the first line of the overall commit message to master, NOT the individual commits, and that requires that the PR review name have the right message.  Hopefully this will be the last one!!!