### PR TITLE
fix: 🐛 update invalid VR type for LUTData

### DIFF
--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -13504,7 +13504,7 @@ const dictionary = {
     },
     "(0028,3006)": {
         tag: "(0028,3006)",
-        vr: "lt",
+        vr: "LT",
         name: "LUTData",
         vm: "1-n",
         version: "DICOM"


### PR DESCRIPTION
Update the Value Representation (VR) for the LUTData tag. It was defined as `lt` instead of `LT`. 

The method `ValueRepresentation.createByTypeString(type)` from `ValueRepresentation.js` couldn't find the right VR class from the `VRInstances` object, and it was creating an `UnknownValue` object. This was causing a crash when reading a file with that tag.

### Context
```
Invalid vr type lt - using UN
(node:28115) UnhandledPromiseRejectionWarning: TypeError: First argument to DataView constructor must be an ArrayBuffer
    at new DataView (<anonymous>)
    at new BufferStream (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:203740)
    at ReadBufferStream._createSuperInternal (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:128580)
    at new ReadBufferStream (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:210562)
    at UnknownValue.writeBytes (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:221335)
    at Tag.write (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:246135)
    at /tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:1105876
    at Array.forEach (<anonymous>)
    at Function.write (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:1105724)
    at SequenceOfItems.writeBytes (/tmp/.mount_RadiobfjpWia/resources/app.asar/index.js:2:235261)
(node:28115) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
```

### Tests
All unit tests pass :heavy_check_mark: 
```
Test Suites: 10 passed, 10 total
Tests:       52 passed, 52 total
Snapshots:   0 total
Time:        5.638 s
Ran all test suites.
```