### PR TITLE
refactor(): use TransferSyntaxUID constants from /constants/dicom.js …

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -1,14 +1,15 @@
-import { ReadBufferStream } from "./BufferStream.js";
-import { DeflatedReadBufferStream } from "./BufferStream.js";
-import { Tag } from "./Tag.js";
-import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
+import { DeflatedReadBufferStream, ReadBufferStream } from "./BufferStream.js";
+import {
+    DEFLATED_EXPLICIT_LITTLE_ENDIAN,
+    EXPLICIT_BIG_ENDIAN,
+    EXPLICIT_LITTLE_ENDIAN,
+    IMPLICIT_LITTLE_ENDIAN
+} from "./constants/dicom";
 import { DicomDict } from "./DicomDict.js";
+import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
+import { Tag } from "./Tag.js";
 import { ValueRepresentation } from "./ValueRepresentation.js";
 
-const IMPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2";
-const EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1";
-const DEFLATED_EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1.99";
-const EXPLICIT_BIG_ENDIAN = "1.2.840.10008.1.2.2";
 const singleVRs = ["SQ", "OF", "OW", "OB", "UN", "LT"];
 
 const encodingMapping = {

--- a/src/Tag.js
+++ b/src/Tag.js
@@ -1,9 +1,10 @@
-import { ValueRepresentation } from "./ValueRepresentation.js";
-import { DicomMessage } from "./DicomMessage.js";
 import { WriteBufferStream } from "./BufferStream.js";
-
-var IMPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2";
-var EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1";
+import {
+    EXPLICIT_LITTLE_ENDIAN,
+    IMPLICIT_LITTLE_ENDIAN
+} from "./constants/dicom";
+import { DicomMessage } from "./DicomMessage.js";
+import { ValueRepresentation } from "./ValueRepresentation.js";
 
 function paddingLeft(paddingValue, string) {
     return String(paddingValue + string).slice(-paddingValue.length);

--- a/src/constants/dicom.js
+++ b/src/constants/dicom.js
@@ -1,14 +1,12 @@
-module.exports = Object.freeze({
-    // TransferSyntaxUIDs
-    IMPLICIT_LITTLE_ENDIAN: "1.2.840.10008.1.2",
-    EXPLICIT_LITTLE_ENDIAN: "1.2.840.10008.1.2.1",
-    DEFLATED_EXPLICIT_LITTLE_ENDIAN: "1.2.840.10008.1.2.1.99",
-    EXPLICIT_BIG_ENDIAN: "1.2.840.10008.1.2.2",
+// TransferSyntaxUIDs
+export const IMPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2";
+export const EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1";
+export const DEFLATED_EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1.99";
+export const EXPLICIT_BIG_ENDIAN = "1.2.840.10008.1.2.2";
 
-    // Data Element Length
-    UNDEFINED_LENGTH: 0xffffffff,
-    ITEM_DELIMITATION_LENGTH: 0x00000000,
+// Data Element Length
+export const UNDEFINED_LENGTH = 0xffffffff;
+export const ITEM_DELIMITATION_LENGTH = 0x00000000;
 
-    // Delimitation Value
-    SEQUENCE_DELIMITATION_VALUE: 0x00000000
-});
+// Delimitation Value
+export const SEQUENCE_DELIMITATION_VALUE = 0x00000000;


### PR DESCRIPTION
…in DicomMessage.js, Tag.js, data.test.js

The /constants/dicom.js was introduced recently ([link to the pull request](https://github.com/dcmjs-org/dcmjs/pull/346)). 

This pull request introduces a refactoring where some classes use the constants from this file to have the definition in a central place. In addition, the linter fixed some small formating issues automatically. I hope the linter settings are correct for this project.

