### PR TITLE
fix: compatibility issue for SEG sourcing MG images

### DIFF
--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -1,1 +1,45 @@
-it("No tests yet", () => {});
+import "regenerator-runtime/runtime.js";
+import fs from "fs";
+import Segmentation_4X from "../src/adapters/Cornerstone/Segmentation_4X"
+import { getTestDataset } from "./testUtils.js";
+
+const mockMetadataProvider = {
+    get: (type, imageId) => {
+        // Unlike CT, is missing coordinate system such as frameOfReferenceUID or rowCosines attributes
+        if (imageId === "mg://1") {
+            return {
+                seriesInstanceUID: "1.2.840.113681.167838594.1562401072.4432.2070.71100000",
+                rows: 3328,
+                columns: 2560,
+                pixelSpacing: [0.065238, 0.065238],
+                rowPixelSpacing: 0.065238,
+                columnPixelSpacing: 0.065238,
+                columnCosines: null,
+                frameOfReferenceUID: undefined,
+                imageOrientationPatient: undefined,
+                imagePositionPatient: undefined,
+                rowCosines: null,
+                sliceLocation: undefined,
+                sliceThickness: undefined
+            };
+        }
+    }
+}
+
+it("Can generate tool state (4X) with SEG sourcing MG images without throwing any errors", async () => {
+    const url =
+        "https://github.com/dcmjs-org/data/releases/download/mg-seg/seg-test-SEG.dcm";
+    const dcmPath = await getTestDataset(url, "seg-test-SEG.dcm")
+    const arrayBuffer = fs.readFileSync(dcmPath).buffer
+
+    expect(
+        () => {
+            Segmentation_4X.generateToolState(
+                ["mg://1"],
+                arrayBuffer,
+                mockMetadataProvider
+            )
+        },
+    ).not.toThrowError();
+
+});


### PR DESCRIPTION
1. Issue overview

I am currently working on a project that automatically generates measurement report from mammography images.
It uses a DICOM web viewer based on OHIF to view its generated results. 

I noticed that the viewer throws an error when it loads the output of our application: mammography and segmentation images. The issue was caused by dcmjs module trying to parse some coordinate related tags from the source image of the SEG (i.e. MG image).

![화면 캡처 2023-04-29 000332](https://user-images.githubusercontent.com/67031139/235184162-060c9f78-a5ce-4e50-a75b-a9ed45e59c60.jpg)

![error_123](https://user-images.githubusercontent.com/67031139/235184780-9a5b5b61-0aaf-4927-8133-7192fbc0da13.jpg)

2. The cause

According to the standard, the segmentation IOD have 2 ways to describe its spatial relationship with the original images: one is using **Frame of Reference UID** along with coordinate system, and the other is having the segmentation pixel size identical to the original image and use **Derivation Image Functional  Group Macro** to describe how each frame and original images are matched. 
(Reference: see page 10 ~ 12 of [suplement 111](https://www.dicomstandard.org/News-dir/ftsup/docs/sups/sup111.pdf) from the DICOM standard for details)

I assume that the former use case is suited for 3D based images such as CT or MRI images, while latter use case is suited for 2D based images such as MG or X-ray images.

However, it seemed that the current version of dcmjs only covers the former use case (using coordinate system) and not covering the latter use case. To be specific, many of codes tries to extract tags from the Image Plane module and the Frame Of Reference module (i.e. 3D coordinate system) without condition. This would cause an error for MG images since modules mentioned above are not included in its IOD definition, while they are mendatory for CT and MRI IODs.

3. Solution

This PR tries to fix the issue by adding conditional statement before trying to extract the coordinate system from sourcing images. If the SEG has Frame of Reference UID, it would extract the Image Plane module from the sourcing images as it is doing in the current version. However, if the SEG does not have Frame of Reference UID, it would simply overlap the SEG frame on top of its sourcing image.

This is how the viewer looks after the fix.

![화면 캡처 2023-04-29 000432](https://user-images.githubusercontent.com/67031139/235192976-9bdf0ce4-c18a-4e8c-9e69-524f7ea6523b.jpg)

The former use case using coordinate system (CT, MRI) also works fine after the fix.

![brain_seg](https://user-images.githubusercontent.com/67031139/235196559-d0f3947c-4e2f-4e8a-8cc2-ec1d62a76cb4.jpg)

However, some modification are ad-hoc to bypass the problem. This is because many of the functions receives data derived from coordinate system as their parameters, and changing those interfaces would increase the risk of degradation.

Also, I only modified the Sementation_4X.js and not the Segmentation_3X.js because I thought this would be enough to cover future deployments and minimize future maintenance overhead.

4. Testing

Regarding the test, I think using jest is not suited for testing this modification:
- The most important part is whether it looks okay when actually displayed.
- The function requires cornerstone metadata provider injection on runtime.
- The test would involve DOM manipulation.

So, I made a demo web page to verify the issue.
- Added a demo web page for testing. See `examples/displaySegmentationSourcingMG/index.html`
- Added a sample dataset (MG, SEG) which is loaded by the demo web page.

To test it on the browser:
- Run `npm run build` and copy the files inside `examples/js`
- Run `npm install --global serve` and `serve examples` to host examples directory on local server.
- Type "http://localhost:3000/displaySegmentationSourcingMG" to open the demo web page. You should be able to verify that the SEG displays fine with MG images on button click.
- Run `git checkout 418cd357fbc5ff3c4d8836a48d102b739c25a26f` if you want to run the unmodified (the error causing) version from the demo page.

The demo web page is for temporary verification purpose just for this pull request. Also, the MG test data is quite big to be stored inside git. 

So, after when this PR is approved, I propose to delete both the data and the demo page, and squash commit before actually merging it.

Any feed backs are welcome.

unit test result:
Test Suites: 13 passed, 13 total
Tests:       67 passed, 67 total
Snapshots:   0 total
Time:        5.829 s