### PR TITLE
fix(segmentation): should use segment number if provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "dcmjs",
-  "version": "0.30.0",
-  "description": "Javascript implementation of DICOM manipulation",
-  "main": "build/dcmjs.js",
-  "module": "build/dcmjs.es.js",
-  "directories": {
-    "example": "examples"
-  },
-  "scripts": {
-    "test": "jest --testTimeout 60000 .",
-    "build": "rollup -c",
-    "build:examples": "npm run build && npx cpx 'build/**/*.{js,map}' examples/js",
-    "start": "rollup -c -w",
-    "format": "prettier --write 'src/**/*.js' 'test/**/*.js'",
-    "lint": "eslint --fix ."
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/dcmjs-org/dcmjs.git"
-  },
-  "author": "Steve Pieper",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/dcmjs-org/dcmjs/issues"
-  },
-  "homepage": "https://github.com/dcmjs-org/dcmjs#readme",
-  "devDependencies": {
-    "@babel/core": "^7.17.8",
-    "@babel/plugin-transform-runtime": "^7.22.5",
-    "@babel/preset-env": "^7.16.11",
-    "@babel/register": "^7.13.0",
-    "@rollup/plugin-babel": "^6.0.3",
-    "@rollup/plugin-commonjs": "^25.0.1",
-    "@rollup/plugin-json": "^6.0.0",
-    "@rollup/plugin-node-resolve": "^15.1.0",
-    "acorn": "^7.1.0",
-    "acorn-jsx": "^5.2.0",
-    "eslint": "^8.17.0",
-    "eslint-config-prettier": "^8.5.0",
-    "follow-redirects": "^1.10.0",
-    "husky": "^1.3.1",
-    "jest": "^27.5.1",
-    "lint-staged": "^13.1.2",
-    "prettier": "^2.6.2",
-    "rollup": "^3.25.1",
-    "xml2js": "^0.4.23"
-  },
-  "dependencies": {
-    "@babel/runtime-corejs3": "^7.22.5",
-    "adm-zip": "^0.5.10",
-    "gl-matrix": "^3.1.0",
-    "lodash.clonedeep": "^4.5.0",
-    "loglevelnext": "^3.0.1",
-    "ndarray": "^1.0.19",
-    "pako": "^2.0.4"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
+    "name": "dcmjs",
+    "version": "0.30.0",
+    "description": "Javascript implementation of DICOM manipulation",
+    "main": "build/dcmjs.js",
+    "module": "build/dcmjs.es.js",
+    "directories": {
+        "example": "examples"
+    },
+    "scripts": {
+        "test": "jest --testTimeout 60000 .",
+        "build": "rollup -c",
+        "build:examples": "npm run build && npx cpx 'build/**/*.{js,map}' examples/js",
+        "start": "rollup -w -c",
+        "format": "prettier --write 'src/**/*.js' 'test/**/*.js'",
+        "lint": "eslint --fix ."
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dcmjs-org/dcmjs.git"
+    },
+    "author": "Steve Pieper",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/dcmjs-org/dcmjs/issues"
+    },
+    "homepage": "https://github.com/dcmjs-org/dcmjs#readme",
+    "devDependencies": {
+        "@babel/core": "^7.17.8",
+        "@babel/plugin-transform-runtime": "^7.22.5",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/register": "^7.13.0",
+        "@rollup/plugin-babel": "^6.0.3",
+        "@rollup/plugin-commonjs": "^25.0.1",
+        "@rollup/plugin-json": "^6.0.0",
+        "@rollup/plugin-node-resolve": "^15.1.0",
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint": "^8.17.0",
+        "eslint-config-prettier": "^8.5.0",
+        "follow-redirects": "^1.10.0",
+        "husky": "^1.3.1",
+        "jest": "^27.5.1",
+        "lint-staged": "^13.1.2",
+        "prettier": "^2.6.2",
+        "rollup": "^3.25.1",
+        "xml2js": "^0.4.23"
+    },
+    "dependencies": {
+        "@babel/runtime-corejs3": "^7.22.5",
+        "adm-zip": "^0.5.10",
+        "gl-matrix": "^3.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "loglevelnext": "^3.0.1",
+        "ndarray": "^1.0.19",
+        "pako": "^2.0.4"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "src/**/*.{js,jsx,json,css}": [
+            "prettier --write",
+            "git add"
+        ]
     }
-  },
-  "lint-staged": {
-    "src/**/*.{js,jsx,json,css}": [
-      "prettier --write",
-      "git add"
-    ]
-  }
 }

--- a/src/derivations/Segmentation.js
+++ b/src/derivations/Segmentation.js
@@ -405,7 +405,9 @@ export default class Segmentation extends DerivedPixels {
         const reNumberedSegmentCopy = {
             SegmentedPropertyCategoryCodeSequence:
                 Segment.SegmentedPropertyCategoryCodeSequence,
-            SegmentNumber: (SegmentSequence.length + 1).toString(),
+            SegmentNumber:
+                Segment.SegmentNumber ||
+                (SegmentSequence.length + 1).toString(),
             SegmentLabel: Segment.SegmentLabel,
             SegmentAlgorithmType,
             RecommendedDisplayCIELabValue:


### PR DESCRIPTION
When exporting segmentation if segment number is specified it the copy should use that instead of deriving it from the length similar to SegmentLabel and SegmentAlgorithm which is used to copy