### PR TITLE
fix: 🐛 Check that VR has accessors for natural types (#368)

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -2,7 +2,6 @@ import dictionary from "./dictionary";
 import log from "./log.js";
 import addAccessors from "./utilities/addAccessors";
 import { ValueRepresentation } from "./ValueRepresentation";
-import dicomJson from "./utilities/dicomJson";
 
 class DicomMetaDictionary {
     // intakes a custom dictionary that will be used to parse/denaturalize the dataset

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -36,7 +36,12 @@ const tagProxyHandler = {
             ValueRepresentation.hasValueAccessors(target.vr)
         ) {
             vrType = ValueRepresentation.createByTypeString(target.vr);
-        } else if (prop in DicomMetaDictionary.nameMap) {
+        } else if (
+            prop in DicomMetaDictionary.nameMap &&
+            ValueRepresentation.hasValueAccessors(
+                DicomMetaDictionary.nameMap[prop].vr
+            )
+        ) {
             vrType = ValueRepresentation.createByTypeString(
                 DicomMetaDictionary.nameMap[prop].vr
             );


### PR DESCRIPTION
When naturalizing a dataset, the ValueRepresentation class used to add accessors may be ambiguous if the tag has multiple VR types. In this case we fall back to no accessor. There are only a handful of tags that fall into this category, and currently only PN has an accessor.

Specifically, this fixes the plethora of errors in OHIF stating `ValueRepresentation.js:262 Invalid vr type xs - using US`