### PR TITLE
feat/nm normalizer

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -357,6 +357,7 @@ class DicomMetaDictionary {
 // Subset of those listed at:
 // http://dicom.nema.org/medical/dicom/current/output/html/part04.html#sect_B.5
 DicomMetaDictionary.sopClassNamesByUID = {
+    "1.2.840.10008.5.1.4.1.1.20": "NMImage",
     "1.2.840.10008.5.1.4.1.1.2": "CTImage",
     "1.2.840.10008.5.1.4.1.1.2.1": "EnhancedCTImage",
     "1.2.840.10008.5.1.4.1.1.2.2": "LegacyConvertedEnhancedCTImage",

--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -83,6 +83,7 @@ class Normalizer {
     static normalizeToDataset(datasets) {
         let sopClassUID = Normalizer.consistentSOPClassUIDs(datasets);
         let normalizerClass = Normalizer.normalizerForSOPClassUID(sopClassUID);
+
         if (!normalizerClass) {
             log.error("no normalizerClass for ", sopClassUID);
             return undefined;
@@ -172,10 +173,6 @@ class ImageNormalizer extends Normalizer {
         let distanceDatasetPairs = [];
         this.datasets.forEach(function (dataset) {
             let position = dataset.ImagePositionPatient.slice();
-            console.log(
-                "NM FORK dataset.ImagePositionPatient.slice() position: ",
-                position
-            );
             let positionVector = ImageNormalizer.vec3Subtract(
                 position,
                 referencePosition
@@ -191,7 +188,7 @@ class ImageNormalizer extends Normalizer {
         if (ds.BitsAllocated !== 16) {
             log.error(
                 "Only works with 16 bit data, not " +
-                String(this.dataset.BitsAllocated)
+                    String(this.dataset.BitsAllocated)
             );
         }
         if (referenceDataset._vrMap && !referenceDataset._vrMap.PixelData) {
@@ -393,32 +390,27 @@ class ImageNormalizer extends Normalizer {
             // provide a volume-level window/level guess (mean of per-frame)
             if (ds.PerFrameFunctionalGroupsSequence) {
                 let wcww = { center: 0, width: 0, count: 0 };
-                ds.PerFrameFunctionalGroupsSequence.forEach(
-                    function (functionalGroup) {
-                        if (functionalGroup.FrameVOILUT) {
-                            let wc =
-                                functionalGroup.FrameVOILUTSequence
-                                    .WindowCenter;
-                            let ww =
-                                functionalGroup.FrameVOILUTSequence.WindowWidth;
-                            if (
-                                functionalGroup.FrameVOILUTSequence &&
-                                wc &&
-                                ww
-                            ) {
-                                if (Array.isArray(wc)) {
-                                    wc = wc[0];
-                                }
-                                if (Array.isArray(ww)) {
-                                    ww = ww[0];
-                                }
-                                wcww.center += Number(wc);
-                                wcww.width += Number(ww);
-                                wcww.count++;
+                ds.PerFrameFunctionalGroupsSequence.forEach(function (
+                    functionalGroup
+                ) {
+                    if (functionalGroup.FrameVOILUT) {
+                        let wc =
+                            functionalGroup.FrameVOILUTSequence.WindowCenter;
+                        let ww =
+                            functionalGroup.FrameVOILUTSequence.WindowWidth;
+                        if (functionalGroup.FrameVOILUTSequence && wc && ww) {
+                            if (Array.isArray(wc)) {
+                                wc = wc[0];
                             }
+                            if (Array.isArray(ww)) {
+                                ww = ww[0];
+                            }
+                            wcww.center += Number(wc);
+                            wcww.width += Number(ww);
+                            wcww.count++;
                         }
                     }
-                );
+                });
                 if (wcww.count > 0) {
                     ds.WindowCenter.push(String(wcww.center / wcww.count));
                     ds.WindowWidth.push(String(wcww.width / wcww.count));

--- a/src/normalizers.js
+++ b/src/normalizers.js
@@ -83,7 +83,6 @@ class Normalizer {
     static normalizeToDataset(datasets) {
         let sopClassUID = Normalizer.consistentSOPClassUIDs(datasets);
         let normalizerClass = Normalizer.normalizerForSOPClassUID(sopClassUID);
-        console.log("HERE-<<<<<<<<");
         if (!normalizerClass) {
             log.error("no normalizerClass for ", sopClassUID);
             return undefined;


### PR DESCRIPTION
This PR adds a normalizer for Nuclear medicine (NM) images. This allows saving a SEG file via the normalizer (from OHIF in our case).  

This code was tested locally using our current version of OHIF (3.8.0-beta.52). The SEG file seen below was created in OHIF, saved via the NM normalizer code and loaded back into OHIF:
![image](https://github.com/dcmjs-org/dcmjs/assets/17124113/a52eda6e-df8d-4f28-9c0d-38401586c575)
