### PR TITLE
feat: Netlify app master-dcmjs2 deploy build

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This is a community effort so please help improve support for a wide range of DICOM data and use cases.
 
-See [live examples here](https://dcmjs2.netlify.com/)
+See [live examples here](https://master--dcmjs2.netlify.app/)
 
 # Goals
 

--- a/test/data-options.test.js
+++ b/test/data-options.test.js
@@ -169,7 +169,7 @@ it("noCopy test_fragment_multiframe", async () => {
         "https://github.com/dcmjs-org/data/releases/download/encapsulation/encapsulation-fragment-multiframe.dcm";
     const dcmPath = await getTestDataset(
         url,
-        "encapsulation-fragment-multiframe.dcm"
+        "encapsulation-fragment-multiframe-b.dcm"
     );
     const file = fs.readFileSync(dcmPath);
 


### PR DESCRIPTION
The change uses the URL that built correctly on the last deploy of dcmjs.  Looks like it should work this time.