### PR TITLE
feat(lossless-round-trip): Implement lossless read writes

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -256,7 +256,7 @@ class DicomMessage {
                 tagObject = jsonObjects[tagString],
                 vrType = tagObject.vr;
 
-            var values = DicomMessage._getTagWriteValue(vrType, tagObject);
+            var values = DicomMessage._getTagWriteValues(vrType, tagObject);
 
             written += tag.write(
                 useStream,
@@ -270,16 +270,17 @@ class DicomMessage {
         return written;
     }
 
-    static _getTagWriteValue(vrType, tagObject) {
+    static _getTagWriteValues(vrType, tagObject) {
         if (!tagObject._rawValue) {
             return tagObject.Value;
         }
 
+        // apply VR specific formatting to the original _rawValue and compare to the Value
         const vr = ValueRepresentation.createByTypeString(vrType);
-        const compareValue = tagObject._rawValue.map((val) => vr.applyFormatting(val))
+        const originalValue = tagObject._rawValue.map((val) => vr.applyFormatting(val))
 
-        // if the _rawValue is unchanged, write it unformatted back to the file
-        if (deepEqual(compareValue, tagObject.Value)) {
+        // if Value has not changed, write _rawValue unformatted back into the file
+        if (deepEqual(tagObject.Value, originalValue)) {
             return tagObject._rawValue;
         } else {
             return tagObject.Value;

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -195,7 +195,8 @@ class DicomMessage {
             ignoreErrors: false,
             untilTag: null,
             includeUntilTagValue: false,
-            noCopy: false
+            noCopy: false,
+            forceStoreRaw: false
         }
     ) {
         var stream = new ReadBufferStream(buffer, null, {
@@ -270,11 +271,11 @@ class DicomMessage {
     }
 
     static _getTagWriteValue(vrType, tagObject) {
-        const vr = ValueRepresentation.createByTypeString(vrType);
-
         if (!tagObject._rawValue) {
             return tagObject.Value;
         }
+
+        const vr = ValueRepresentation.createByTypeString(vrType);
         const compareValue = tagObject._rawValue.map((val) => vr.applyFormatting(val))
 
         // if the _rawValue is unchanged, write it unformatted back to the file
@@ -364,12 +365,12 @@ class DicomMessage {
             var times = length / vr.maxLength,
                 i = 0;
             while (i++ < times) {
-                const { rawValue, value } = vr.read(stream, vr.maxLength, syntax);
+                const { rawValue, value } = vr.read(stream, vr.maxLength, syntax, options);
                 rawValues.push(rawValue);
                 values.push(value);
             }
         } else {
-            const { rawValue, value } = vr.read(stream, length, syntax);
+            const { rawValue, value } = vr.read(stream, length, syntax, options);
             if (!vr.isBinary() && singleVRs.indexOf(vr.type) == -1) {
                 rawValues = rawValue;
                 values = value

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -346,29 +346,28 @@ class DicomMessage {
             var times = length / vr.maxLength,
                 i = 0;
             while (i++ < times) {
-                const rawValue = vr.read(stream, vr.maxLength, syntax);
+                const { rawValue, value } = vr.read(stream, vr.maxLength, syntax);
                 rawValues.push(rawValue);
-                values.push(vr.applyFormatting(rawValue));
+                values.push(value);
             }
         } else {
-            var rawVal = vr.read(stream, length, syntax);
+            const { rawValue, value } = vr.read(stream, length, syntax);
             if (!vr.isBinary() && singleVRs.indexOf(vr.type) == -1) {
-                rawValues = rawVal;
-                if (vr.type == 'PN') {
-                    values = vr.applyFormatting(rawVal);
-                } else if (typeof rawVal === "string") {
-                    rawValues = rawVal.split(String.fromCharCode(VM_DELIMITER));
-                    values = rawValues.map(str => vr.applyFormatting(str));
+                rawValues = rawValue;
+                values = value
+                if (typeof value === "string") {
+                    rawValues = rawValue.split(String.fromCharCode(VM_DELIMITER));
+                    values = value.split(String.fromCharCode(VM_DELIMITER));
                 }
             } else if (vr.type == "SQ") {
-                rawValues = rawVal;
-                values = vr.applyFormatting(rawVal);
+                rawValues = rawValue;
+                values = value;
             } else if (vr.type == "OW" || vr.type == "OB") {
-                rawValues = rawVal;
-                values = vr.applyFormatting(rawVal);
+                rawValues = rawValue;
+                values = value;
             } else {
-                Array.isArray(rawVal) ? (values = rawVal.map(str => vr.applyFormatting(str))) : values.push(rawVal);
-                Array.isArray(rawVal) ? (rawValues = rawVal) : rawValues.push(vr.applyFormatting(rawVal));
+                Array.isArray(value) ? (values = value) : values.push(value);
+                Array.isArray(rawValue) ? (rawValues = rawValue) : rawValues.push(rawValue);
             }
         }
         stream.setEndian(oldEndian);

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -1334,30 +1334,21 @@ class ParsedUnknownValue extends BinaryRepresentation {
         const streamFromBuffer = new ReadBufferStream(arrayBuffer, true);
         const vr = ValueRepresentation.createByTypeString(this.type);
 
-        var values = [];
         if (vr.isBinary() && length > vr.maxLength && !vr.noMultiple) {
+            var values = [];
+            var rawValues = [];
             var times = length / vr.maxLength,
                 i = 0;
-            while (i++ < times) {
-                values.push(vr.read(streamFromBuffer, vr.maxLength, syntax));
-            }
-        } else {
-            var val = vr.read(streamFromBuffer, length, syntax);
-            if (!vr.isBinary() && singleVRs.indexOf(vr.type) == -1) {
-                values = val;
-                if (typeof val === "string") {
-                    values = val.split(String.fromCharCode(VM_DELIMITER));
-                }
-            } else if (vr.type == "SQ") {
-                values = val;
-            } else if (vr.type == "OW" || vr.type == "OB") {
-                values = val;
-            } else {
-                Array.isArray(val) ? (values = val) : values.push(val);
-            }
-        }
 
-        return values;
+            while (i++ < times) {
+                const { rawValue, value } = vr.read(streamFromBuffer, vr.maxLength, syntax);
+                rawValues.push(rawValue);
+                values.push(value);
+            }
+            return { rawValue: rawValues, value: values };
+        } else {
+            return vr.read(streamFromBuffer, length, syntax);
+        }
     }
 }
 
@@ -1431,4 +1422,4 @@ let VRinstances = {
     UT: new UnlimitedText()
 };
 
-export { ValueRepresentation };
+export {ValueRepresentation};

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -646,13 +646,10 @@ class DecimalString extends AsciiStringRepresentation {
 
         if (ds.indexOf(BACKSLASH) !== -1) {
             // handle decimal string with multiplicity
-            const dsArray = ds.split(BACKSLASH);
-            ds = dsArray.map(ds => (ds === "" ? null : ds));
+            return ds.split(BACKSLASH);
         } else {
-            ds = [ds === "" ? null : ds];
+           return [ds];
         }
-
-        return ds;
     }
 
     applyFormatting(value) {
@@ -787,13 +784,11 @@ class IntegerString extends AsciiStringRepresentation {
 
         if (is.indexOf(BACKSLASH) !== -1) {
             // handle integer string with multiplicity
-            const integerStringArray = is.split(BACKSLASH);
-            is = integerStringArray.map(is => (is === "" ? null : is));
+            return is.split(BACKSLASH);
         } else {
-            is = [is === "" ? null : is];
+            return [is];
         }
 
-        return is;
     }
 
     applyFormatting(value) {

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -1317,7 +1317,6 @@ class UnknownValue extends BinaryRepresentation {
     }
 }
 
-// TODO Craig: Need to come back and analyze this
 class ParsedUnknownValue extends BinaryRepresentation {
     constructor(vr) {
         super(vr);

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -583,11 +583,18 @@ class CodeString extends AsciiStringRepresentation {
     }
 
     readBytes(stream, length) {
-        return stream.readAsciiString(length);
+        const BACKSLASH = String.fromCharCode(VM_DELIMITER);
+        return stream.readAsciiString(length).split(BACKSLASH);
     }
 
     applyFormatting(value) {
-        return value.trim();
+        const trim = (str) => str.trim();
+
+        if (Array.isArray(value)) {
+            return value.map((str) => trim(str));
+        }
+
+        return trim(value);
     }
 }
 

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -137,7 +137,7 @@ class ValueRepresentation {
                         length
                 );
         }
-        return this.applyFormatting(this.readBytes(stream, length, syntax));
+        return this.readBytes(stream, length, syntax);
     }
 
     applyFormatting(value) {
@@ -641,20 +641,12 @@ class DecimalString extends AsciiStringRepresentation {
     }
 
     readBytes(stream, length) {
-        const BACKSLASH = String.fromCharCode(VM_DELIMITER);
-        let ds = stream.readAsciiString(length);
-
-        if (ds.indexOf(BACKSLASH) !== -1) {
-            // handle decimal string with multiplicity
-            return ds.split(BACKSLASH);
-        } else {
-           return [ds];
-        }
+        return stream.readAsciiString(length);
     }
 
     applyFormatting(value) {
         const formatNumber = (numberStr) => {
-            let returnVal = numberStr.replace(/[^0-9.\\\-+e]/gi, "");
+            let returnVal = numberStr.trim().replace(/[^0-9.\\\-+e]/gi, "");
             return returnVal === "" ? null : Number(returnVal);
         }
 
@@ -779,21 +771,12 @@ class IntegerString extends AsciiStringRepresentation {
     }
 
     readBytes(stream, length) {
-        const BACKSLASH = String.fromCharCode(VM_DELIMITER);
-        let is = stream.readAsciiString(length).trim();
-
-        if (is.indexOf(BACKSLASH) !== -1) {
-            // handle integer string with multiplicity
-            return is.split(BACKSLASH);
-        } else {
-            return [is];
-        }
-
+        return stream.readAsciiString(length);
     }
 
     applyFormatting(value) {
         const formatNumber = (numberStr) => {
-            let returnVal = numberStr.replace(/[^0-9.\\\-+e]/gi, "");
+            let returnVal = numberStr.trim().replace(/[^0-9.\\\-+e]/gi, "");
             return returnVal === "" ? null : Number(returnVal);
         }
 
@@ -1252,23 +1235,23 @@ class UniqueIdentifier extends AsciiStringRepresentation {
     }
 
     readBytes(stream, length) {
-        const result = this.readPaddedAsciiString(stream, length);
-
-        const BACKSLASH = String.fromCharCode(VM_DELIMITER);
-
-        // Treat backslashes as a delimiter for multiple UIDs, in which case an
-        // array of UIDs is returned. This is used by DICOM Q&R to support
-        // querying and matching multiple items on a UID field in a single
-        // query. For more details see:
+        return this.readPaddedAsciiString(stream, length);
         //
-        // https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_C.2.2.2.2.html
-        // https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.4.html
-
-        if (result.indexOf(BACKSLASH) === -1) {
-            return result
-        } else {
-            return result.split(BACKSLASH)
-        }
+        // const BACKSLASH = String.fromCharCode(VM_DELIMITER);
+        //
+        // // Treat backslashes as a delimiter for multiple UIDs, in which case an
+        // // array of UIDs is returned. This is used by DICOM Q&R to support
+        // // querying and matching multiple items on a UID field in a single
+        // // query. For more details see:
+        // //
+        // // https://dicom.nema.org/medical/dicom/current/output/chtml/part04/sect_C.2.2.2.2.html
+        // // https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.4.html
+        //
+        // if (result.indexOf(BACKSLASH) === -1) {
+        //     return result
+        // } else {
+        //     return result.split(BACKSLASH)
+        // }
     }
 
     applyFormatting(value) {

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -107,7 +107,7 @@ class ValueRepresentation {
      * The `_rawValue` is used for lossless round trip processing, which preserves data (whitespace, special chars) on write
      * that may be lost after casting to other data structures like Number, or applying formatting for readability.
      *
-     * Example: DecimalString: _rawValue: ["-0.000"], Value: [0]
+     * Example DecimalString: _rawValue: ["-0.000"], Value: [0]
      */
     storeRaw() {
         return this._storeRaw;
@@ -1013,7 +1013,6 @@ class SequenceOfItems extends ValueRepresentation {
         this._storeRaw = false;
     }
 
-    // TODO Craig: potentially need special logic for sequences when writing
     readBytes(stream, sqlength, syntax) {
         if (sqlength == 0x0) {
             return []; //contains no dataset
@@ -1286,6 +1285,7 @@ class UniqueIdentifier extends AsciiStringRepresentation {
 
     readBytes(stream, length) {
         const result = this.readPaddedAsciiString(stream, length);
+
         const BACKSLASH = String.fromCharCode(VM_DELIMITER);
 
         // Treat backslashes as a delimiter for multiple UIDs, in which case an
@@ -1303,7 +1303,6 @@ class UniqueIdentifier extends AsciiStringRepresentation {
         }
     }
 
-    // TODO: Can we make the array formatting generic in value representaiton base
     applyFormatting(value) {
         const removeInvalidUidChars = (uidStr) => {
             return uidStr.replace(/[^0-9.]/g, "");

--- a/src/utilities/deepEqual.js
+++ b/src/utilities/deepEqual.js
@@ -1,26 +1,35 @@
-
+/**
+ * Performs a deep equality check between two objects. Used primarily during DICOM write operations
+ * to determine whether a data element underlying value has changed since it was initially read.
+ *
+ * @param {Object} obj1 - The first object to compare.
+ * @param {Object} obj2 - The second object to compare.
+ * @returns {boolean} - Returns `true` if the structures and values of the objects are deeply equal, `false` otherwise.
+ */
 export function deepEqual(obj1, obj2) {
-    // Base case: If both objects are identical, return true.
+    // Use Object.is to consider for treatment of `NaN` and signed 0's i.e. `+0` or `-0` in IS/DS
     if (Object.is(obj1, obj2)) {
         return true;
     }
-    // Check if both objects are objects and not null.
+
+    // expect objects or a null instance if initial check failed
     if (typeof obj1 !== 'object' || typeof obj2 !== 'object' || obj1 === null || obj2 === null) {
         return false;
     }
-    // Get the keys of both objects.
+
+    // all keys should match a deep equality check
     const keys1 = Object.keys(obj1);
     const keys2 = Object.keys(obj2);
-    // Check if the number of keys is the same.
+
     if (keys1.length !== keys2.length) {
         return false;
     }
-    // Iterate through the keys and compare their values recursively.
+
     for (const key of keys1) {
         if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
             return false;
         }
     }
-    // If all checks pass, the objects are deep equal.
+
     return true;
 }

--- a/src/utilities/deepEqual.js
+++ b/src/utilities/deepEqual.js
@@ -1,0 +1,26 @@
+
+export function deepEqual(obj1, obj2) {
+    // Base case: If both objects are identical, return true.
+    if (Object.is(obj1, obj2)) {
+        return true;
+    }
+    // Check if both objects are objects and not null.
+    if (typeof obj1 !== 'object' || typeof obj2 !== 'object' || obj1 === null || obj2 === null) {
+        return false;
+    }
+    // Get the keys of both objects.
+    const keys1 = Object.keys(obj1);
+    const keys2 = Object.keys(obj2);
+    // Check if the number of keys is the same.
+    if (keys1.length !== keys2.length) {
+        return false;
+    }
+    // Iterate through the keys and compare their values recursively.
+    for (const key of keys1) {
+        if (!keys2.includes(key) || !deepEqual(obj1[key], obj2[key])) {
+            return false;
+        }
+    }
+    // If all checks pass, the objects are deep equal.
+    return true;
+}

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1345,7 +1345,7 @@ describe("test_un_vr", () => {
                 dicomDict.dict = dataset;
 
                 // Write and re-read
-                const outputDicomDict = DicomMessage.readFile(dicomDict.write());
+                const outputDicomDict = DicomMessage.readFile(dicomDict.write(), { forceStoreRaw: true });
 
                 // Expect tag to be parsed correctly based on meta dictionary vr lookup
                 expect(outputDicomDict.dict[tag].vr).toEqual(vr);

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1281,6 +1281,55 @@ describe("test_un_vr", () => {
                 ["  Feeling nauseous  "],
                 ["  Feeling nauseous"]
             ],
+            [
+                '21000050',
+                'TM',
+                new Uint8Array([0x34,0x32,0x35,0x33,0x30,0x2E,0x31,0x32,0x33,0x34,0x35,0x36]).buffer,
+                ["42530.123456"],
+                ["42530.123456"]
+            ],
+            [
+                '3010001B',
+                'UC',
+                new Uint8Array([0x54, 0x72, 0x61, 0x69, 0x6C, 0x69, 0x6E, 0x67, 0x20, 0x73, 0x70, 0x61, 0x63, 0x65, 0x73, 0x20, 0x61, 0x6C, 0x6C, 0x6F, 0x77, 0x65, 0x64, 0x20, 0x20, 0x20]).buffer,
+                ["Trailing spaces allowed   "],
+                ["Trailing spaces allowed"]
+            ],
+            [
+                '00041510',
+                'UI',
+                new Uint8Array([0x31,0x2E,0x32,0x2E,0x38,0x34,0x30,0x2E,0x31,0x30,0x30,0x30,0x38,0x2E,0x31,0x2E,0x32,0x2E,0x31]).buffer,
+                ["1.2.840.10008.1.2.1"],
+                ["1.2.840.10008.1.2.1"]
+            ],
+            [
+                '30100092',
+                'UL',
+                new Uint8Array([0x40, 0xE2, 0x01, 0x00]).buffer,
+                [123456],
+                [123456]
+            ],
+            [
+                '0008010E',
+                'UR',
+                new Uint8Array([0x68,0x74,0x74,0x70,0x3A,0x2F,0x2F,0x64,0x69,0x63,0x6F,0x6D,0x2E,0x6E,0x65,0x6D,0x61,0x2E,0x6F,0x72,0x67, 0x20]).buffer,
+                ["http://dicom.nema.org "],
+                ["http://dicom.nema.org "],
+            ],
+            [
+                '00080301',
+                'US',
+                new Uint8Array([0xD2, 0x04]).buffer,
+                [1234],
+                [1234],
+            ],
+            [
+                '0008030E',
+                'UT',
+                new Uint8Array([0x20,0x20,0x46,0x65,0x65,0x6C,0x69,0x6E,0x67,0x20,0x6E,0x61,0x75,0x73,0x65,0x6F,0x75,0x73,0x20,0x20]).buffer,
+                ["  Feeling nauseous  "],
+                ["  Feeling nauseous"]
+            ],
         ])(
             "for tag %s with expected VR %p",
             (tag, vr, byteArray, expectedRawValue, expectedValue) => {

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -348,7 +348,6 @@ it("test_null_number_vrs", () => {
     expect(dataset.InstanceNumber).toEqual(null);
 });
 
-// TODO Craig: Fix writing logic then compare actual differences (need to look at specific character set)
 it("test_exponential_notation", () => {
     const file = fs.readFileSync("test/sample-dicom.dcm");
     const data = dcmjs.data.DicomMessage.readFile(file.buffer, {
@@ -358,7 +357,9 @@ it("test_exponential_notation", () => {
     dataset.ImagePositionPatient[2] = 7.1945578383e-5;
     const buffer = data.write();
     const copy = dcmjs.data.DicomMessage.readFile(buffer);
-    expect(JSON.stringify(data)).toEqual(JSON.stringify(copy));
+    const datasetCopy = dcmjs.data.DicomMetaDictionary.naturalizeDataset(copy.dict);
+
+    expect(dataset.ImagePositionPatient).toEqual(datasetCopy.ImagePositionPatient);
 });
 
 it("test_output_equality", () => {

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -348,6 +348,7 @@ it("test_null_number_vrs", () => {
     expect(dataset.InstanceNumber).toEqual(null);
 });
 
+// TODO Craig: Fix writing logic then compare actual differences (need to look at specific character set)
 it("test_exponential_notation", () => {
     const file = fs.readFileSync("test/sample-dicom.dcm");
     const data = dcmjs.data.DicomMessage.readFile(file.buffer, {
@@ -1106,6 +1107,7 @@ describe("The same DICOM file loaded from both DCM and JSON", () => {
     });
 });
 
+// TODO Craig: Need to add more tests here
 describe("test_un_vr", () => {
     it("Tag with UN vr should be parsed according VR in dictionary", async () => {
         const expectedExposureIndex = 662;

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1149,7 +1149,7 @@ it.each([
     "A converted decimal string should not exceed 16 bytes in length",
     (a, expected) => {
         const decimalString = ValueRepresentation.createByTypeString("DS");
-        let value = decimalString.formatValue(a);
+        let value = decimalString.convertToString(a);
         expect(value.length).toBeLessThanOrEqual(16);
         expect(value).toBe(expected);
     }

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1108,7 +1108,6 @@ describe("The same DICOM file loaded from both DCM and JSON", () => {
     });
 });
 
-// TODO Craig: Need to add more tests here
 describe("test_un_vr", () => {
     it("Tag with UN vr should be parsed according VR in dictionary", async () => {
         const expectedExposureIndex = 662;

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1131,6 +1131,181 @@ describe("test_un_vr", () => {
         expect(dataset.ExposureIndex).toEqual(expectedExposureIndex);
         expect(dataset.DeviationIndex).toEqual(expectedDeviationIndex);
     });
+
+    describe("Test other VRs encoded as UN", () => {
+        test.each([
+            [
+                '00000600',
+                'AE',
+                new Uint8Array([0x20, 0x20, 0x54, 0x45, 0x53, 0x54, 0x5F, 0x41, 0x45, 0x20]).buffer,
+                ["  TEST_AE "],
+                ["TEST_AE"]
+            ],
+            [
+                '00101010',
+                'AS',
+                new Uint8Array([0x30, 0x34, 0x35, 0x59]).buffer,
+                ["045Y"],
+                ["045Y"]
+            ],
+            [
+                '00280009',
+                'AT',
+                new Uint8Array([0x63, 0x10, 0x18, 0x00]).buffer,
+                [0x10630018],
+                [0x10630018]
+            ],
+            [
+                '00041130',
+                'CS',
+                new Uint8Array([0x4F, 0x52, 0x49, 0x47, 0x49, 0x4E, 0x41, 0x4C, 0x20, 0x20, 0x5C, 0x20, 0x50, 0x52, 0x49, 0x4D, 0x41, 0x52, 0x59, 0x20]).buffer,
+                ["ORIGINAL  ", " PRIMARY "],
+                ["ORIGINAL", "PRIMARY"]
+            ],
+            [
+                '00181012',
+                'DA',
+                new Uint8Array([0x32, 0x30, 0x32, 0x34, 0x30, 0x31, 0x30, 0x31]).buffer,
+                ["20240101"],
+                ["20240101"]
+            ],
+            [
+                '00181041',
+                'DS',
+                new Uint8Array([0x30, 0x30, 0x30, 0x30, 0x31, 0x32, 0x33, 0x2E, 0x34, 0x35]).buffer,
+                ["0000123.45"],
+                [123.45]
+            ],
+            [
+                '00181078',
+                'DT',
+                new Uint8Array([0x32, 0x30, 0x32, 0x34, 0x30, 0x31, 0x30, 0x31, 0x31, 0x32, 0x33, 0x30, 0x34, 0x35, 0x2E, 0x31, 0x20, 0x20]).buffer,
+                ["20240101123045.1  "],
+                ["20240101123045.1  "]
+            ],
+            [
+                '00182043',
+                'FL',
+                new Uint8Array([0x66, 0x66, 0xA6, 0x3F, 0x66, 0x66, 0xA6, 0x3F]).buffer,
+                [1.2999999523162842, 1.2999999523162842],
+                [1.2999999523162842, 1.2999999523162842]
+            ],
+            [
+                '00186028',
+                'FD',
+                new Uint8Array([0x11, 0x2D, 0x44, 0x54, 0xFB, 0x21, 0x09, 0x40]).buffer,
+                [3.14159265358979],
+                [3.14159265358979]
+            ],
+            [
+                '00200012',
+                'IS',
+                new Uint8Array([0x20,0x2B,0x32,0x37,0x38,0x39,0x33,0x20]).buffer,
+                [" +27893 "],
+                [27893]
+            ],
+            [
+                '0018702A',
+                'LO',
+                new Uint8Array([0x20,0x20,0x46,0x65,0x65,0x6C,0x69,0x6E,0x67,0x20,0x6E,0x61,0x75,0x73,0x65,0x6F,0x75,0x73,0x20,0x20]).buffer,
+                ["  Feeling nauseous  "],
+                ["Feeling nauseous"]
+            ],
+            [
+                '00187040',
+                'LT',
+                new Uint8Array([0x20,0x20,0x46,0x65,0x65,0x6C,0x69,0x6E,0x67,0x20,0x6E,0x61,0x75,0x73,0x65,0x6F,0x75,0x73,0x20,0x20]).buffer,
+                ["  Feeling nauseous  "],
+                ["  Feeling nauseous"]
+            ],
+            [
+                '00282000',
+                'OB',
+                new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer,
+                [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+                [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer]
+            ],
+            [
+                '00701A07',
+                'OD',
+                new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer,
+                [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
+                [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer]
+            ],
+            [
+                '00720067',
+                'OF',
+                new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer,
+                [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
+                [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer]
+            ],
+            [
+                '00281224',
+                'OW',
+                new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer,
+                [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+                [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer]
+            ],
+            [
+                '00080090',
+                'PN',
+                new Uint8Array([0x44, 0x6F, 0x65, 0x5E, 0x4A, 0x6F, 0x68, 0x6E, 0x5E, 0x41, 0x5E, 0x4A, 0x72, 0x2E, 0x5E, 0x4D, 0x44, 0x3D, 0x44, 0x6F, 0x65, 0x5E, 0x4A, 0x61, 0x79, 0x5E, 0x41, 0x5E, 0x4A, 0x72, 0x2E, 0x20]).buffer,
+                ["Doe^John^A^Jr.^MD=Doe^Jay^A^Jr."],
+                [{"Alphabetic": "Doe^John^A^Jr.^MD", "Ideographic": "Doe^Jay^A^Jr."}]
+            ],
+            [
+                '00080094',
+                'SH',
+                new Uint8Array([0x43,0x54,0x5F,0x53,0x43,0x41,0x4E,0x5F,0x30,0x31]).buffer,
+                ["CT_SCAN_01"],
+                ["CT_SCAN_01"]
+            ],
+            [
+                '00186020',
+                'SL',
+                new Uint8Array([0x40, 0xE2, 0x01, 0x00, 0x40, 0xE2, 0x01, 0x00]).buffer,
+                [123456, 123456],
+                [123456, 123456]
+            ],
+            [
+                '00189219',
+                'SS',
+                new Uint8Array([0xD2, 0x04, 0xD2, 0x04, 0xD2, 0x04]).buffer,
+                [1234, 1234, 1234],
+                [1234, 1234, 1234]
+            ],
+            [
+                '00189373',
+                'ST',
+                new Uint8Array([0x20,0x20,0x46,0x65,0x65,0x6C,0x69,0x6E,0x67,0x20,0x6E,0x61,0x75,0x73,0x65,0x6F,0x75,0x73,0x20,0x20]).buffer,
+                ["  Feeling nauseous  "],
+                ["  Feeling nauseous"]
+            ],
+        ])(
+            "for tag %s with expected VR %p",
+            (tag, vr, byteArray, expectedRawValue, expectedValue) => {
+                // setup input tag as UN
+                const dataset = {
+                    [tag]: {
+                        vr: "UN",
+                        _rawValue: [byteArray],
+                        Value: [byteArray],
+                    },
+                };
+
+                const dicomDict = new DicomDict({});
+                dicomDict.dict = dataset;
+
+                // Write and re-read
+                const outputDicomDict = DicomMessage.readFile(dicomDict.write());
+
+                // Expect tag to be parsed correctly based on meta dictionary vr lookup
+                expect(outputDicomDict.dict[tag].vr).toEqual(vr);
+                expect(outputDicomDict.dict[tag]._rawValue).toEqual(expectedRawValue);
+                expect(outputDicomDict.dict[tag].Value).toEqual(expectedValue);
+            }
+        );
+    });
 });
 
 it.each([

--- a/test/lossless-read-write.test.js
+++ b/test/lossless-read-write.test.js
@@ -1,14 +1,12 @@
 import "regenerator-runtime/runtime.js";
 
 import fs from "fs";
-import path from "path";
 import dcmjs from "../src/index.js";
 import {deepEqual} from "../src/utilities/deepEqual";
 
-import {getTestDataset, getZippedTestDataset} from "./testUtils";
+import {getTestDataset} from "./testUtils";
 
-const { DicomMetaDictionary, DicomDict, DicomMessage, ReadBufferStream } =
-    dcmjs.data;
+const {DicomDict, DicomMessage} = dcmjs.data;
 
 
 describe('lossless-read-write', () => {
@@ -16,16 +14,16 @@ describe('lossless-read-write', () => {
     describe('storeRaw option', () => {
         const dataset = {
             '00080008': {
-                "vr": "CS",
-                "Value": ["DERIVED"],
+                vr: "CS",
+                Value: ["DERIVED"],
             },
             "00082112": {
-                "vr": "SQ",
-                "Value": [
+                vr: "SQ",
+                Value: [
                     {
                         "00081150": {
-                            "vr": "UI",
-                            "Value": [
+                            vr: "UI",
+                            Value: [
                                 "1.2.840.10008.5.1.4.1.1.7"
                             ],
                         },
@@ -33,28 +31,28 @@ describe('lossless-read-write', () => {
                 ]
             },
             "00180050": {
-                "vr": "DS",
-                "Value": [1],
+                vr: "DS",
+                Value: [1],
             },
             "00181708": {
-                "vr": "IS",
-                "Value": [426],
+                vr: "IS",
+                Value: [426],
             },
             "00189328": {
-                "vr": "FD",
-                "Value": [30.98],
+                vr: "FD",
+                Value: [30.98],
             },
             "0020000D": {
-                "vr": "UI",
-                "Value": ["1.3.6.1.4.1.5962.99.1.2280943358.716200484.1363785608958.3.0"],
+                vr: "UI",
+                Value: ["1.3.6.1.4.1.5962.99.1.2280943358.716200484.1363785608958.3.0"],
             },
             "00400254": {
-                "vr": "LO",
-                "Value": ["DUCTO/GALACTOGRAM 1 DUCT LT"],
+                vr: "LO",
+                Value: ["DUCTO/GALACTOGRAM 1 DUCT LT"],
             },
             "7FE00010": {
-                "vr": "OW",
-                "Value": [new Uint8Array([0x00, 0x00]).buffer]
+                vr: "OW",
+                Value: [new Uint8Array([0x00, 0x00]).buffer]
             }
         };
 
@@ -66,7 +64,7 @@ describe('lossless-read-write', () => {
 
             // write and re-read
             const outputDicomDict = DicomMessage.readFile(dicomDict.write());
-            for (const tag in outputDicomDict.dict ) {
+            for (const tag in outputDicomDict.dict) {
                 if (tagsWithoutRaw.includes(tag)) {
                     expect(outputDicomDict.dict[tag]._rawValue).toBeFalsy();
                 } else {
@@ -82,14 +80,13 @@ describe('lossless-read-write', () => {
             dicomDict.dict = dataset;
 
             // write and re-read
-            const outputDicomDict = DicomMessage.readFile(dicomDict.write(), { forceStoreRaw: true});
+            const outputDicomDict = DicomMessage.readFile(dicomDict.write(), {forceStoreRaw: true});
 
-            for (const tag in outputDicomDict.dict ) {
+            for (const tag in outputDicomDict.dict) {
                 expect(outputDicomDict.dict[tag]._rawValue).toBeTruthy();
             }
         });
     });
-
 
     test('test DS value with additional allowed characters is written to file', () => {
         const dataset = {
@@ -131,379 +128,461 @@ describe('lossless-read-write', () => {
         expect(outputDicomDict.dict['00181041'].Value).toEqual([9007199254740992])
     });
 
-    const unchangedTestCases = [
-        {
-            vr: "AE",
-            _rawValue: ["  TEST_AE "], // spaces non-significant for interpretation but allowed
-            Value: ["TEST_AE"],
-        },
-        {
-            vr: "AS",
-            _rawValue: ["045Y"],
-            Value: ["045Y"],
-        },
-        {
-            vr: "AT",
-            _rawValue: [0x00207E14, 0x0012839A],
-            Value: [0x00207E14, 0x0012839A],
-        },
-        {
-            vr: "CS",
-            _rawValue: ["ORIGINAL  ", " PRIMARY "], // spaces non-significant for interpretation but allowed
-            Value: ["ORIGINAL", "PRIMARY"],
-        },
-        {
-            vr: "DA",
-            _rawValue: ["20240101"],
-            Value: ["20240101"],
-        },
-        {
-            vr: "DS",
-            _rawValue: ["0000123.45"], // leading zeros allowed
-            Value: [123.45],
-        },
-        {
-            vr: 'DT',
-            _rawValue: ["20240101123045.1  "], // trailing spaces allowed
-            Value: ["20240101123045.1  "],
-        },
-        {
-            vr: 'FL',
-            _rawValue: [3.125],
-            Value: [3.125],
-        },
-        {
-            vr: 'FD',
-            _rawValue: [3.14159265358979], // trailing spaces allowed
-            Value: [3.14159265358979],
-        },
-        {
-            vr: 'IS',
-            _rawValue: [" -123   "], // leading/trailing spaces & sign allowed
-            Value: [-123],
-        },
-        {
-            vr: 'LO',
-            _rawValue: [" A long string with spaces    "], // leading/trailing spaces allowed
-            Value: ["A long string with spaces"],
-        },
-        {
-            vr: 'LT',
-            _rawValue: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b. "], // leading spaces significant, trailing spaces allowed
-            Value: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b."],
-        },
-        {
-            vr: 'OB',
-            _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
-            Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
-        },
-        {
-            vr: 'OD',
-            _rawValue: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
-            Value: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
-        },
-        {
-            vr: 'OF',
-            _rawValue: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
-            Value: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
-        },
-        // TODO: VRs currently unimplemented
-        // {
-        //     vr: 'OL',
-        //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
-        //     Value: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
-        // },
-        // {
-        //     vr: 'OV',
-        //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
-        //     Value: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
-        // },
-        {
-            vr: 'OW',
-            _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
-            Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
-        },
-        {
-            vr: 'PN',
-            _rawValue: ["Doe^John^A^Jr.^MD  "], // trailing spaces allowed
-            Value: [{"Alphabetic": "Doe^John^A^Jr.^MD  "}],
-        },
-        {
-            vr: 'SH',
-            _rawValue: [" CT_SCAN_01 "], // leading/trailing spaces allowed
-            Value: ["CT_SCAN_01"],
-        },
-        {
-            vr: 'SL',
-            _rawValue: [-2147483648],
-            Value: [-2147483648],
-        },
-        {
-            vr: 'SS',
-            _rawValue: [-32768, 1234, 832],
-            Value: [-32768, 1234, 832],
-        },
-        {
-            vr: 'ST',
-            _rawValue: ["Patient complains of headaches over the last week.    "], // trailing spaces allowed
-            Value: ["Patient complains of headaches over the last week."],
-        },
-        // TODO: VR currently unimplemented
-        // {
-        //     vr: 'SV',
-        //     _rawValue: [9007199254740993], // trailing spaces allowed
-        //     Value: [9007199254740993],
-        // },
-        {
-            vr: 'TM',
-            _rawValue: ["42530.123456  "], // trailing spaces allowed
-            Value: ["42530.123456"],
-        },
-        {
-            vr: 'UC',
-            _rawValue: ["Detailed description of procedure or clinical notes that could be very long.  "], // trailing spaces allowed
-            Value: ["Detailed description of procedure or clinical notes that could be very long."],
-        },
-        {
-            vr: 'UI',
-            _rawValue: ["1.2.840.10008.1.2.1"],
-            Value: ["1.2.840.10008.1.2.1"],
-        },
-        {
-            vr: 'UL',
-            _rawValue: [4294967295],
-            Value: [4294967295],
-        },
-        {
-            vr: 'UR',
-            _rawValue: ["http://dicom.nema.org "], // trailing spaces ignored but allowed
-            Value: ["http://dicom.nema.org "],
-        },
-        {
-            vr: 'US',
-            _rawValue: [65535],
-            Value: [65535],
-        },
-        {
-            vr: 'UT',
-            _rawValue: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset.  "], // leading spaces significant, trailing spaces allowed
-            Value: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset."],
-        },
-        // TODO: VR currently unimplemented
-        // {
-        //     vr: 'UV',
-        //     _rawValue: [18446744073709551616], // 2^64
-        //     Value: [18446744073709551616],
-        // },
-    ];
+    describe('Individual VR comparisons', () => {
 
-    test.each(unchangedTestCases)(
-        `Test unchanged value is retained following read and write - $vr`,
-        (dataElement) => {
+        const unchangedTestCases = [
+            {
+                vr: "AE",
+                _rawValue: ["  TEST_AE "], // spaces non-significant for interpretation but allowed
+                Value: ["TEST_AE"],
+            },
+            {
+                vr: "AS",
+                _rawValue: ["045Y"],
+                Value: ["045Y"],
+            },
+            {
+                vr: "AT",
+                _rawValue: [0x00207E14, 0x0012839A],
+                Value: [0x00207E14, 0x0012839A],
+            },
+            {
+                vr: "CS",
+                _rawValue: ["ORIGINAL  ", " PRIMARY "], // spaces non-significant for interpretation but allowed
+                Value: ["ORIGINAL", "PRIMARY"],
+            },
+            {
+                vr: "DA",
+                _rawValue: ["20240101"],
+                Value: ["20240101"],
+            },
+            {
+                vr: "DS",
+                _rawValue: ["0000123.45"], // leading zeros allowed
+                Value: [123.45],
+            },
+            {
+                vr: 'DT',
+                _rawValue: ["20240101123045.1  "], // trailing spaces allowed
+                Value: ["20240101123045.1  "],
+            },
+            {
+                vr: 'FL',
+                _rawValue: [3.125],
+                Value: [3.125],
+            },
+            {
+                vr: 'FD',
+                _rawValue: [3.14159265358979], // trailing spaces allowed
+                Value: [3.14159265358979],
+            },
+            {
+                vr: 'IS',
+                _rawValue: [" -123   "], // leading/trailing spaces & sign allowed
+                Value: [-123],
+            },
+            {
+                vr: 'LO',
+                _rawValue: [" A long string with spaces    "], // leading/trailing spaces allowed
+                Value: ["A long string with spaces"],
+            },
+            {
+                vr: 'LT',
+                _rawValue: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b. "], // leading spaces significant, trailing spaces allowed
+                Value: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b."],
+            },
+            {
+                vr: 'OB',
+                _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+                Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+            },
+            {
+                vr: 'OD',
+                _rawValue: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
+                Value: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
+            },
+            {
+                vr: 'OF',
+                _rawValue: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
+                Value: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
+            },
+            // TODO: VRs currently unimplemented
+            // {
+            //     vr: 'OL',
+            //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
+            //     Value: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
+            // },
+            // {
+            //     vr: 'OV',
+            //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
+            //     Value: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
+            // },
+            {
+                vr: 'OW',
+                _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+                Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+            },
+            {
+                vr: 'PN',
+                _rawValue: ["Doe^John^A^Jr.^MD  "], // trailing spaces allowed
+                Value: [{"Alphabetic": "Doe^John^A^Jr.^MD  "}],
+            },
+            {
+                vr: 'SH',
+                _rawValue: [" CT_SCAN_01 "], // leading/trailing spaces allowed
+                Value: ["CT_SCAN_01"],
+            },
+            {
+                vr: 'SL',
+                _rawValue: [-2147483648],
+                Value: [-2147483648],
+            },
+            {
+                vr: 'SS',
+                _rawValue: [-32768, 1234, 832],
+                Value: [-32768, 1234, 832],
+            },
+            {
+                vr: 'ST',
+                _rawValue: ["Patient complains of headaches over the last week.    "], // trailing spaces allowed
+                Value: ["Patient complains of headaches over the last week."],
+            },
+            // TODO: VR currently unimplemented
+            // {
+            //     vr: 'SV',
+            //     _rawValue: [9007199254740993], // trailing spaces allowed
+            //     Value: [9007199254740993],
+            // },
+            {
+                vr: 'TM',
+                _rawValue: ["42530.123456  "], // trailing spaces allowed
+                Value: ["42530.123456"],
+            },
+            {
+                vr: 'UC',
+                _rawValue: ["Detailed description of procedure or clinical notes that could be very long.  "], // trailing spaces allowed
+                Value: ["Detailed description of procedure or clinical notes that could be very long."],
+            },
+            {
+                vr: 'UI',
+                _rawValue: ["1.2.840.10008.1.2.1"],
+                Value: ["1.2.840.10008.1.2.1"],
+            },
+            {
+                vr: 'UL',
+                _rawValue: [4294967295],
+                Value: [4294967295],
+            },
+            {
+                vr: 'UR',
+                _rawValue: ["http://dicom.nema.org "], // trailing spaces ignored but allowed
+                Value: ["http://dicom.nema.org "],
+            },
+            {
+                vr: 'US',
+                _rawValue: [65535],
+                Value: [65535],
+            },
+            {
+                vr: 'UT',
+                _rawValue: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset.  "], // leading spaces significant, trailing spaces allowed
+                Value: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset."],
+            },
+            // TODO: VR currently unimplemented
+            // {
+            //     vr: 'UV',
+            //     _rawValue: [18446744073709551616], // 2^64
+            //     Value: [18446744073709551616],
+            // },
+        ];
+        test.each(unchangedTestCases)(
+            `Test unchanged value is retained following read and write - $vr`,
+            (dataElement) => {
+                const dataset = {
+                    '00181041': {
+                        ...dataElement
+                    },
+                };
+
+                const dicomDict = new DicomDict({});
+                dicomDict.dict = dataset;
+
+                // write and re-read
+                const outputDicomDict = DicomMessage.readFile(dicomDict.write(), {forceStoreRaw: true});
+
+                // expect raw value to be unchanged, and Value parsed as Number to lose precision
+                expect(outputDicomDict.dict['00181041']._rawValue).toEqual(dataElement._rawValue)
+                expect(outputDicomDict.dict['00181041'].Value).toEqual(dataElement.Value)
+            }
+        )
+
+        const changedTestCases = [
+            {
+                vr: "AE",
+                _rawValue: ["  TEST_AE "], // spaces non-significant for interpretation but allowed
+                Value: ["NEW_AE"],
+            },
+            {
+                vr: "AS",
+                _rawValue: ["045Y"],
+                Value: ["999Y"],
+            },
+            {
+                vr: "AT",
+                _rawValue: [0x00207E14, 0x0012839A],
+                Value: [0x00200010],
+            },
+            {
+                vr: "CS",
+                _rawValue: ["ORIGINAL  ", " PRIMARY "], // spaces non-significant for interpretation but allowed
+                Value: ["ORIGINAL", "PRIMARY", "SECONDARY"],
+            },
+            {
+                vr: "DA",
+                _rawValue: ["20240101"],
+                Value: ["20231225"],
+            },
+            {
+                vr: "DS",
+                _rawValue: ["0000123.45"], // leading zeros allowed
+                Value: [123.456],
+                newRawValue: ["123.456 "]
+            },
+            {
+                vr: 'DT',
+                _rawValue: ["20240101123045.1  "], // trailing spaces allowed
+                Value: ["20240101123045.3"],
+            },
+            {
+                vr: 'FL',
+                _rawValue: [3.125],
+                Value: [22],
+            },
+            {
+                vr: 'FD',
+                _rawValue: [3.14159265358979], // trailing spaces allowed
+                Value: [50.1242],
+            },
+            {
+                vr: 'IS',
+                _rawValue: [" -123   "], // leading/trailing spaces & sign allowed
+                Value: [0],
+                newRawValue: ["0 "]
+            },
+            {
+                vr: 'LO',
+                _rawValue: [" A long string with spaces    "], // leading/trailing spaces allowed
+                Value: ["A changed string that is still long."],
+            },
+            {
+                vr: 'LT',
+                _rawValue: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b. "], // leading spaces significant, trailing spaces allowed
+                Value: [" A modified string of text"],
+            },
+            {
+                vr: 'OB',
+                _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+                Value: [new Uint8Array([0x01, 0x02]).buffer],
+            },
+            {
+                vr: 'OD',
+                _rawValue: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
+                Value: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x35, 0x6E, 0x9E, 0x42]).buffer],
+            },
+            {
+                vr: 'OF',
+                _rawValue: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
+                Value: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x43]).buffer],
+            },
+            // TODO: VRs currently unimplemented
+            // {
+            //     vr: 'OL',
+            //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
+            // },
+            // {
+            //     vr: 'OV',
+            //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
+            // },
+            {
+                vr: 'OW',
+                _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x89, 0x91, 0x89, 0x89]).buffer],
+                Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+            },
+            {
+                vr: 'PN',
+                _rawValue: ["Doe^John^A^Jr.^MD  "], // trailing spaces allowed
+                Value: [{"Alphabetic": "Doe^Jane^A^Jr.^MD"}],
+                newRawValue: ["Doe^Jane^A^Jr.^MD"]
+            },
+            {
+                vr: 'SH',
+                _rawValue: [" CT_SCAN_01 "], // leading/trailing spaces allowed
+                Value: ["MR_SCAN_91"],
+            },
+            {
+                vr: 'SL',
+                _rawValue: [-2147483648],
+                Value: [-2147481234],
+            },
+            {
+                vr: 'SS',
+                _rawValue: [-32768, 1234, 832],
+                Value: [1234],
+            },
+            {
+                vr: 'ST',
+                _rawValue: ["Patient complains of headaches over the last week.    "], // trailing spaces allowed
+                Value: ["Patient complains of headaches"],
+            },
+            // TODO: VR currently unimplemented
+            // {
+            //     vr: 'SV',
+            //     _rawValue: [9007199254740993], // trailing spaces allowed
+            // },
+            {
+                vr: 'TM',
+                _rawValue: ["42530.123456  "], // trailing spaces allowed
+                Value: ["42530"],
+                newRawValue: ["42530 "]
+            },
+            {
+                vr: 'UC',
+                _rawValue: ["Detailed description of procedure or clinical notes that could be very long.  "], // trailing spaces allowed
+                Value: ["Detailed description of procedure and other things"],
+            },
+            {
+                vr: 'UI',
+                _rawValue: ["1.2.840.10008.1.2.1"],
+                Value: ["1.2.840.10008.1.2.2"],
+            },
+            {
+                vr: 'UL',
+                _rawValue: [4294967295],
+                Value: [1],
+            },
+            {
+                vr: 'UR',
+                _rawValue: ["http://dicom.nema.org "], // trailing spaces ignored but allowed
+                Value: ["https://github.com/dcmjs-org"],
+            },
+            {
+                vr: 'US',
+                _rawValue: [65535],
+                Value: [1],
+            },
+            {
+                vr: 'UT',
+                _rawValue: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset.  "], // leading spaces significant, trailing spaces allowed
+                Value: [""],
+            },
+            // TODO: VR currently unimplemented
+            // {
+            //     vr: 'UV',
+            //     _rawValue: [18446744073709551616], // 2^64
+            // },
+        ];
+
+        test.each(changedTestCases)(
+            `Test changed value overwrites original value following read and write - $vr`,
+            (dataElement) => {
+                const dataset = {
+                    '00181041': {
+                        ...dataElement
+                    },
+                };
+
+                const dicomDict = new DicomDict({});
+                dicomDict.dict = dataset;
+
+                // write and re-read
+                const outputDicomDict = DicomMessage.readFile(dicomDict.write(), {forceStoreRaw: true});
+
+                // expect raw value to be updated to match new Value parsed as Number to lose precision
+                expect(outputDicomDict.dict['00181041']._rawValue).toEqual(dataElement.newRawValue ?? dataElement.Value)
+                expect(outputDicomDict.dict['00181041'].Value).toEqual(dataElement.Value)
+            }
+        )
+
+    });
+
+    describe('sequences', () => {
+        test('nested sequences should support lossless round trip', () => {
             const dataset = {
-                '00181041': {
-                    ...dataElement
-                },
+                "52009229": {
+                    vr: "SQ",
+                    Value: [
+                        {
+                            "0020000E": {
+                                vr: "UI",
+                                Value: ["1.3.6.1.4.1.5962.99.1.2280943358.716200484.1363785608958.1.1"]
+                            },
+                            "00089123": {
+                                vr: "SQ",
+                                Value: [
+                                    {
+                                        "00181030": {
+                                            vr: "AE",
+                                            _rawValue: ["  TEST_AE "],
+                                            Value: ["TEST_AE"],
+                                        },
+                                        "00180050": {
+                                            vr: "DS",
+                                            Value: [5.0],
+                                           _rawValue: ["5.000 "]
+                                        }
+                                    },
+                                    {
+                                        "00181030": {
+                                            vr: "AE",
+                                            _rawValue: ["  TEST_AE "],
+                                            Value: ["TEST_AE"],
+                                        },
+                                        "00180050": {
+                                            vr: "DS",
+                                            Value: [6.0],
+                                           _rawValue: ["6.000 "]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "0020000E": {
+                                vr: "UI",
+                                Value: ["1.3.6.1.4.1.5962.99.1.2280943358.716200484.1363785608958.1.2"]
+                            },
+                            "00089123": {
+                                vr: "SQ",
+                                Value: [
+                                    {
+                                        "00181030": {
+                                            vr: "LO",
+                                            Value: ["ABDOMEN MRI"]
+                                        },
+                                        "00180050": {
+                                            vr: 'IS',
+                                            _rawValue: [" -123   "], // leading/trailing spaces & sign allowed
+                                            Value: [-123],
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
             };
-
+            
             const dicomDict = new DicomDict({});
             dicomDict.dict = dataset;
 
-            // write and re-read
-            const outputDicomDict = DicomMessage.readFile(dicomDict.write(), { forceStoreRaw: true });
+            // confirm after write raw values are re-encoded
+            const outputBuffer = dicomDict.write();
+            const outputDicomDict = DicomMessage.readFile(outputBuffer);
 
-            // expect raw value to be unchanged, and Value parsed as Number to lose precision
-            expect(outputDicomDict.dict['00181041']._rawValue).toEqual(dataElement._rawValue)
-            expect(outputDicomDict.dict['00181041'].Value).toEqual(dataElement.Value)
-        }
-    )
-
-    const changedTestCases = [
-        {
-            vr: "AE",
-            _rawValue: ["  TEST_AE "], // spaces non-significant for interpretation but allowed
-            Value: ["NEW_AE"],
-        },
-        {
-            vr: "AS",
-            _rawValue: ["045Y"],
-            Value: ["999Y"],
-        },
-        {
-            vr: "AT",
-            _rawValue: [0x00207E14, 0x0012839A],
-            Value: [0x00200010],
-        },
-        {
-            vr: "CS",
-            _rawValue: ["ORIGINAL  ", " PRIMARY "], // spaces non-significant for interpretation but allowed
-            Value: ["ORIGINAL", "PRIMARY", "SECONDARY"],
-        },
-        {
-            vr: "DA",
-            _rawValue: ["20240101"],
-            Value: ["20231225"],
-        },
-        {
-            vr: "DS",
-            _rawValue: ["0000123.45"], // leading zeros allowed
-            Value: [123.456],
-            newRawValue: ["123.456 "]
-        },
-        {
-            vr: 'DT',
-            _rawValue: ["20240101123045.1  "], // trailing spaces allowed
-            Value: ["20240101123045.3"],
-        },
-        {
-            vr: 'FL',
-            _rawValue: [3.125],
-            Value: [22],
-        },
-        {
-            vr: 'FD',
-            _rawValue: [3.14159265358979], // trailing spaces allowed
-            Value: [50.1242],
-        },
-        {
-            vr: 'IS',
-            _rawValue: [" -123   "], // leading/trailing spaces & sign allowed
-            Value: [0],
-            newRawValue: ["0 "]
-        },
-        {
-            vr: 'LO',
-            _rawValue: [" A long string with spaces    "], // leading/trailing spaces allowed
-            Value: ["A changed string that is still long."],
-        },
-        {
-            vr: 'LT',
-            _rawValue: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b. "], // leading spaces significant, trailing spaces allowed
-            Value: [" A modified string of text"],
-        },
-        {
-            vr: 'OB',
-            _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
-            Value: [new Uint8Array([0x01, 0x02]).buffer],
-        },
-        {
-            vr: 'OD',
-            _rawValue: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
-            Value: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x35, 0x6E, 0x9E, 0x42]).buffer],
-        },
-        {
-            vr: 'OF',
-            _rawValue: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
-            Value: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x43]).buffer],
-        },
-        // TODO: VRs currently unimplemented
-        // {
-        //     vr: 'OL',
-        //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
-        // },
-        // {
-        //     vr: 'OV',
-        //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
-        // },
-        {
-            vr: 'OW',
-            _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x89, 0x91, 0x89, 0x89]).buffer],
-            Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
-        },
-        {
-            vr: 'PN',
-            _rawValue: ["Doe^John^A^Jr.^MD  "], // trailing spaces allowed
-            Value: [{"Alphabetic": "Doe^Jane^A^Jr.^MD"}],
-            newRawValue: ["Doe^Jane^A^Jr.^MD"]
-        },
-        {
-            vr: 'SH',
-            _rawValue: [" CT_SCAN_01 "], // leading/trailing spaces allowed
-            Value: ["MR_SCAN_91"],
-        },
-        {
-            vr: 'SL',
-            _rawValue: [-2147483648],
-            Value: [-2147481234],
-        },
-        {
-            vr: 'SS',
-            _rawValue: [-32768, 1234, 832],
-            Value: [1234],
-        },
-        {
-            vr: 'ST',
-            _rawValue: ["Patient complains of headaches over the last week.    "], // trailing spaces allowed
-            Value: ["Patient complains of headaches"],
-        },
-        // TODO: VR currently unimplemented
-        // {
-        //     vr: 'SV',
-        //     _rawValue: [9007199254740993], // trailing spaces allowed
-        // },
-        {
-            vr: 'TM',
-            _rawValue: ["42530.123456  "], // trailing spaces allowed
-            Value: ["42530"],
-            newRawValue: ["42530 "]
-        },
-        {
-            vr: 'UC',
-            _rawValue: ["Detailed description of procedure or clinical notes that could be very long.  "], // trailing spaces allowed
-            Value: ["Detailed description of procedure and other things"],
-        },
-        {
-            vr: 'UI',
-            _rawValue: ["1.2.840.10008.1.2.1"],
-            Value: ["1.2.840.10008.1.2.2"],
-        },
-        {
-            vr: 'UL',
-            _rawValue: [4294967295],
-            Value: [1],
-        },
-        {
-            vr: 'UR',
-            _rawValue: ["http://dicom.nema.org "], // trailing spaces ignored but allowed
-            Value: ["https://github.com/dcmjs-org"],
-        },
-        {
-            vr: 'US',
-            _rawValue: [65535],
-            Value: [1],
-        },
-        {
-            vr: 'UT',
-            _rawValue: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset.  "], // leading spaces significant, trailing spaces allowed
-            Value: [""],
-        },
-        // TODO: VR currently unimplemented
-        // {
-        //     vr: 'UV',
-        //     _rawValue: [18446744073709551616], // 2^64
-        // },
-    ];
-
-    test.each(changedTestCases)(
-        `Test changed value overwrites original value following read and write - $vr`,
-        (dataElement) => {
-            const dataset = {
-                '00181041': {
-                    ...dataElement
-                },
-            };
-
-            const dicomDict = new DicomDict({});
-            dicomDict.dict = dataset;
-
-            // write and re-read
-            const outputDicomDict = DicomMessage.readFile(dicomDict.write(), { forceStoreRaw: true });
-
-            // expect raw value to be updated to match new Value parsed as Number to lose precision
-            expect(outputDicomDict.dict['00181041']._rawValue).toEqual(dataElement.newRawValue ?? dataElement.Value)
-            expect(outputDicomDict.dict['00181041'].Value).toEqual(dataElement.Value)
-        }
-    )
+            // lossless read/write should match entire data set
+            deepEqual(dicomDict.dict, outputDicomDict.dict)
+        })
+    })
 
     test('File dataset should be equal after read and write', async () => {
         const inputBuffer = await getDcmjsDataFile("unknown-VR", "sample-dicom-with-un-vr.dcm");

--- a/test/lossless-read-write.test.js
+++ b/test/lossless-read-write.test.js
@@ -80,8 +80,8 @@ describe('lossless-read-write', () => {
         },
         {
             vr: "AT",
-            _rawValue: [0x00207E14],
-            Value: [0x00207E14],
+            _rawValue: [0x00207E14, 0x0012839A],
+            Value: [0x00207E14, 0x0012839A],
         },
         {
             vr: "CS",
@@ -176,8 +176,8 @@ describe('lossless-read-write', () => {
         },
         {
             vr: 'SS',
-            _rawValue: [-32768],
-            Value: [-32768],
+            _rawValue: [-32768, 1234, 832],
+            Value: [-32768, 1234, 832],
         },
         {
             vr: 'ST',

--- a/test/lossless-read-write.test.js
+++ b/test/lossless-read-write.test.js
@@ -1,0 +1,88 @@
+import "regenerator-runtime/runtime.js";
+
+import fs from "fs";
+import path from "path";
+import dcmjs from "../src/index.js";
+import {deepEqual} from "../src/utilities/deepEqual";
+
+import {getTestDataset, getZippedTestDataset} from "./testUtils";
+
+const { DicomMetaDictionary, DicomDict, DicomMessage, ReadBufferStream } =
+    dcmjs.data;
+
+// export const PIXEL_DATA_HEX_TAG = '7FE00010';
+//
+// // compare files at binary level
+// const compareArrayBuffers = (buf1, buf2) => {
+//     const dv1 = new Int8Array(buf1);
+//     const dv2 = new Int8Array(buf2);
+//     for (let i = 0; i < buf1.byteLength; i += 1) {
+//         if (dv1[i] !== dv2[i]) {
+//             return false;
+//         }
+//     }
+//     if (buf1.byteLength !== buf2.byteLength) return false;
+//     return true;
+// };
+
+describe('lossless-read-write', () => {
+    // test('reading and writing a file should not change the underlying data', async () => {
+    //     // const url = "https://github.com/dcmjs-org/data/releases/download/encapsulation/encapsulation.dcm";
+    //     // const dcmPath = await getTestDataset(url, "encapsulation.dcm");
+    //
+    //     const inputBuffer = fs.readFileSync("test/terumo.dcm").buffer;
+    //
+    //     // given
+    //     // const inputBuffer = fs.readFileSync(dcmPath).buffer;
+    //     const dicomDict = DicomMessage.readFile(inputBuffer);
+    //
+    //     const outputBuffer = dicomDict.write({ fragmentMultiframe: true, allowInvalidVRLength: false });
+    //     const outputDicomDict = DicomMessage.readFile(outputBuffer);
+    //
+    //
+    //
+    //     fs.writeFile(`terumo-dcmjs-multifragment.dcm`, Buffer.from(outputBuffer), function (err) {
+    //         if (err) {
+    //             return console.log(err);
+    //         }
+    //         console.log("The file was saved!");
+    //     });
+    //
+    //     expect(
+    //         compareArrayBuffers(
+    //             dicomDict.dict[PIXEL_DATA_HEX_TAG].Value[0],
+    //             outputDicomDict.dict[PIXEL_DATA_HEX_TAG].Value[0]
+    //         )
+    //     ).toEqual(true);
+    //
+    //     expect(compareArrayBuffers(inputBuffer, outputBuffer)).toEqual(true);
+    // });
+
+    test('test', async () => {
+        const inputBuffer = await getDcmjsDataFile("unknown-VR", "sample-dicom-with-un-vr.dcm");
+        const dicomDict = DicomMessage.readFile(inputBuffer);
+
+        // confirm raw string representation of DS contains extra additional metadata
+        // represented by bytes [30 2E 31 34 30 5C 30 2E 31 34 30 20]
+        expect(dicomDict.dict['00280030']._rawValue).toEqual(["0.140", "0.140 "])
+        expect(dicomDict.dict['00280030'].Value).toEqual([0.14, 0.14])
+
+        // confirm after write raw values are re-encoded
+        const outputBuffer = dicomDict.write();
+        const outputDicomDict = DicomMessage.readFile(outputBuffer);
+
+        // explicitly verify for DS for clarity
+        expect(outputDicomDict.dict['00280030']._rawValue).toEqual(["0.140", "0.140 "])
+        expect(outputDicomDict.dict['00280030'].Value).toEqual([0.14, 0.14])
+
+        // lossless read/write should match entire data set
+        deepEqual(dicomDict.dict, outputDicomDict.dict)
+    });
+});
+
+const getDcmjsDataFile = async (release, fileName) => {
+    const url = "https://github.com/dcmjs-org/data/releases/download/" + release + "/" + fileName;
+    const dcmPath = await getTestDataset(url, fileName);
+
+    return fs.readFileSync(dcmPath).buffer;
+}

--- a/test/lossless-read-write.test.js
+++ b/test/lossless-read-write.test.js
@@ -123,16 +123,118 @@ describe('lossless-read-write', () => {
             _rawValue: [" A long string with spaces    "], // leading/trailing spaces allowed
             Value: ["A long string with spaces"],
         },
+        {
+            vr: 'LT',
+            _rawValue: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b. "], // leading spaces significant, trailing spaces allowed
+            Value: ["  It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b."],
+        },
+        {
+            vr: 'OB',
+            _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+            Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+        },
+        {
+            vr: 'OD',
+            _rawValue: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
+            Value: [new Uint8Array([0x00, 0x00, 0x00, 0x54, 0x34, 0x6F, 0x9D, 0x41]).buffer],
+        },
+        {
+            vr: 'OF',
+            _rawValue: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
+            Value: [new Uint8Array([0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0xF6, 0x42]).buffer],
+        },
+        // TODO: VRs currently unimplemented
         // {
-        //     vr: 'LT',
-        //     _rawValue: ["It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b."],
-        //     Value: ["It may contain the Graphic Character set and the Control Characters, CR\r, LF\n, FF\f, and ESC\x1b."],
+        //     vr: 'OL',
+        //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
+        //     Value: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41, 0x00, 0x00, 0xF6, 0x42, 0x00, 0x00, 0x28, 0x41]).buffer],
+        // },
+        // {
+        //     vr: 'OV',
+        //     _rawValue: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
+        //     Value: [new Uint8Array([0x00, 0x00, 0x30, 0xC0, 0x00, 0x00, 0x28, 0x41]).buffer],
+        // },
+        {
+            vr: 'OW',
+            _rawValue: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+            Value: [new Uint8Array([0x13, 0x40, 0x80, 0x88, 0x88, 0x90, 0x88, 0x88]).buffer],
+        },
+        {
+            vr: 'PN',
+            _rawValue: ["Doe^John^A^Jr.^MD  "], // trailing spaces allowed
+            Value: [{"Alphabetic": "Doe^John^A^Jr.^MD  "}],
+        },
+        {
+            vr: 'SH',
+            _rawValue: [" CT_SCAN_01 "], // leading/trailing spaces allowed
+            Value: ["CT_SCAN_01"],
+        },
+        {
+            vr: 'SL',
+            _rawValue: [-2147483648],
+            Value: [-2147483648],
+        },
+        {
+            vr: 'SS',
+            _rawValue: [-32768],
+            Value: [-32768],
+        },
+        {
+            vr: 'ST',
+            _rawValue: ["Patient complains of headaches over the last week.    "], // trailing spaces allowed
+            Value: ["Patient complains of headaches over the last week."],
+        },
+        // TODO: VR currently unimplemented
+        // {
+        //     vr: 'SV',
+        //     _rawValue: [9007199254740993], // trailing spaces allowed
+        //     Value: [9007199254740993],
+        // },
+        {
+            vr: 'TM',
+            _rawValue: ["42530.123456  "], // trailing spaces allowed
+            Value: ["42530.123456"],
+        },
+        {
+            vr: 'UC',
+            _rawValue: ["Detailed description of procedure or clinical notes that could be very long.  "], // trailing spaces allowed
+            Value: ["Detailed description of procedure or clinical notes that could be very long."],
+        },
+        {
+            vr: 'UI',
+            _rawValue: ["1.2.840.10008.1.2.1"],
+            Value: ["1.2.840.10008.1.2.1"],
+        },
+        {
+            vr: 'UL',
+            _rawValue: [4294967295],
+            Value: [4294967295],
+        },
+        {
+            vr: 'UR',
+            _rawValue: ["http://dicom.nema.org "], // trailing spaces ignored but allowed
+            Value: ["http://dicom.nema.org "],
+        },
+        {
+            vr: 'US',
+            _rawValue: [65535],
+            Value: [65535],
+        },
+        {
+            vr: 'UT',
+            _rawValue: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset.  "], // leading spaces significant, trailing spaces allowed
+            Value: ["    This is a detailed explanation that can span multiple lines and paragraphs in the DICOM dataset."],
+        },
+        // TODO: VR currently unimplemented
+        // {
+        //     vr: 'UV',
+        //     _rawValue: [18446744073709551616], // 2^64
+        //     Value: [18446744073709551616],
         // },
     ];
 
-
     test.each(unchangedTestCases)(
-        "Test unchanged value is retained following read and write",
+        `Test unchanged value is retained following read and write - $vr`,
         (dataElement) => {
             const dataset = {
                 '00181041': {

--- a/test/utilities/deepEqual.test.js
+++ b/test/utilities/deepEqual.test.js
@@ -1,0 +1,78 @@
+import { deepEqual } from "../../src/utilities/deepEqual";
+
+describe('deepEqual', () => {
+    test('returns true for identical primitives', () => {
+        expect(deepEqual(42, 42)).toBe(true);
+        expect(deepEqual('hello', 'hello')).toBe(true);
+        expect(deepEqual(true, true)).toBe(true);
+        expect(deepEqual(null, null)).toBe(true);
+    });
+
+    test('returns false for different primitives', () => {
+        expect(deepEqual(42, 43)).toBe(false);
+        expect(deepEqual('hello', 'world')).toBe(false);
+        expect(deepEqual(true, false)).toBe(false);
+        expect(deepEqual(null, undefined)).toBe(false);
+    });
+
+    test('verify special mathematical numbers', () => {
+        expect(deepEqual(Math.NaN, Math.NaN)).toBe(true);
+        expect(deepEqual(-0, 0)).toBe(false);
+        expect(deepEqual(-0, +0)).toBe(false);
+    })
+
+    test('returns true for deeply equal objects', () => {
+        const obj1 = { a: 1, b: { c: 2 } };
+        const obj2 = { a: 1, b: { c: 2 } };
+        expect(deepEqual(obj1, obj2)).toBe(true);
+    });
+
+    test('returns false for objects with different structures', () => {
+        const obj1 = { a: 1, b: { c: 2 } };
+        const obj2 = { a: 1, b: { d: 2 } };
+        expect(deepEqual(obj1, obj2)).toBe(false);
+    });
+
+    test('returns false for objects with different values', () => {
+        const obj1 = { a: 1, b: { c: 2 } };
+        const obj2 = { a: 1, b: { c: 3 } };
+        expect(deepEqual(obj1, obj2)).toBe(false);
+    });
+
+    test('returns true for deeply equal arrays', () => {
+        const arr1 = [1, 2, { a: 3 }];
+        const arr2 = [1, 2, { a: 3 }];
+        expect(deepEqual(arr1, arr2)).toBe(true);
+    });
+
+    test('returns false for arrays with different values', () => {
+        const arr1 = [1, 2, { a: 3 }];
+        const arr2 = [1, 2, { a: 4 }];
+        expect(deepEqual(arr1, arr2)).toBe(false);
+    });
+
+    test('returns false for objects compared with arrays', () => {
+        const obj = { a: 1, b: 2 };
+        const arr = [1, 2];
+        expect(deepEqual(obj, arr)).toBe(false);
+    });
+
+    test('returns false for different object types', () => {
+        const date1 = new Date(2024, 0, 1);
+        const date2 = new Date(2024, 0, 1);
+        const obj1 = { a: 1, b: 2 };
+        expect(deepEqual(date1, obj1)).toBe(false);
+    });
+
+    test('returns true for nested objects with arrays', () => {
+        const obj1 = { a: 1, b: [1, 2, { c: 3 }] };
+        const obj2 = { a: 1, b: [1, 2, { c: 3 }] };
+        expect(deepEqual(obj1, obj2)).toBe(true);
+    });
+
+    test('returns false for functions, as they should not be equal', () => {
+        const obj1 = { a: 1, b: function() { return 2; } };
+        const obj2 = { a: 1, b: function() { return 2; } };
+        expect(deepEqual(obj1, obj2)).toBe(false);
+    });
+});

--- a/test/utilities/deepEqual.test.js
+++ b/test/utilities/deepEqual.test.js
@@ -15,7 +15,7 @@ describe('deepEqual', () => {
         expect(deepEqual(null, undefined)).toBe(false);
     });
 
-    test('verify special mathematical numbers', () => {
+    test('returns same value check for signed zeros and special numbers', () => {
         expect(deepEqual(Math.NaN, Math.NaN)).toBe(true);
         expect(deepEqual(-0, 0)).toBe(false);
         expect(deepEqual(-0, +0)).toBe(false);


### PR DESCRIPTION
Solves https://github.com/dcmjs-org/dcmjs/issues/398 by implementing lossless round trip read/writes to preserve original file data when tags are unmodified

- Extracts any formatting or manipulation done to data element values into `ValueRepresentation.applyFormatting`
- Maintain reference to original value via new `_rawValue` property on a data element
- Detect changes to `Value` during writes to determine whether to maintain original unformatted value or update
- Filter `BinaryValueRepresentation` from lossless processing by default to avoid duplicating large arrayBuffers like pixel data, but provide override mechanism via `readOptions`
