### PR TITLE
fix(lossles-round-trip): Account for padding byte in numeric strings with multiplicity

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -11,7 +11,7 @@ import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
 import { Tag } from "./Tag.js";
 import { log } from "./log.js";
 import { deepEqual } from "./utilities/deepEqual";
-import { ValueRepresentation } from "./ValueRepresentation.js";
+import { dropPadByte, ValueRepresentation } from "./ValueRepresentation.js";
 
 const singleVRs = ["SQ", "OF", "OW", "OB", "UN", "LT"];
 
@@ -376,7 +376,7 @@ class DicomMessage {
                 rawValues = rawValue;
                 values = value
                 if (typeof value === "string") {
-                    rawValues = rawValue.split(String.fromCharCode(VM_DELIMITER));
+                    rawValues = dropPadByte(rawValue.split(String.fromCharCode(VM_DELIMITER)), vr);
                     values = value.split(String.fromCharCode(VM_DELIMITER));
                 }
             } else if (vr.type == "SQ") {

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -11,7 +11,7 @@ import { DicomMetaDictionary } from "./DicomMetaDictionary.js";
 import { Tag } from "./Tag.js";
 import { log } from "./log.js";
 import { deepEqual } from "./utilities/deepEqual";
-import { dropPadByte, ValueRepresentation } from "./ValueRepresentation.js";
+import { ValueRepresentation } from "./ValueRepresentation.js";
 
 const singleVRs = ["SQ", "OF", "OW", "OB", "UN", "LT"];
 
@@ -376,8 +376,9 @@ class DicomMessage {
                 rawValues = rawValue;
                 values = value
                 if (typeof value === "string") {
-                    rawValues = dropPadByte(rawValue.split(String.fromCharCode(VM_DELIMITER)), vr);
-                    values = value.split(String.fromCharCode(VM_DELIMITER));
+                    const delimiterChar = String.fromCharCode(VM_DELIMITER);
+                    rawValues = vr.dropPadByte(rawValue.split(delimiterChar))
+                    values = value.split(delimiterChar);
                 }
             } else if (vr.type == "SQ") {
                 rawValues = rawValue;

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -378,7 +378,7 @@ class DicomMessage {
                 if (typeof value === "string") {
                     const delimiterChar = String.fromCharCode(VM_DELIMITER);
                     rawValues = vr.dropPadByte(rawValue.split(delimiterChar))
-                    values = value.split(delimiterChar);
+                    values = vr.dropPadByte(value.split(delimiterChar));
                 }
             } else if (vr.type == "SQ") {
                 rawValues = rawValue;

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -668,8 +668,8 @@ class NumericStringRepresentation extends AsciiStringRepresentation {
         const numStr = stream.readAsciiString(length);
         const nums = numStr.split(BACKSLASH);
 
-        // final element in list may have a padding byte for even length, this should be removed as it is not part of
-        // the original value and prevents max length issues during write
+        // final element in multiplicity array may have a padding byte for even length, remove if this exceeds the max
+        // allowed length to prevent errors during write
         if (nums.length > 1) {
             const last = nums[nums.length - 1];
 

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -149,7 +149,8 @@ class ValueRepresentation {
      * @returns {string[]} The modified array, with the padding byte potentially removed from the last value.
      */
     dropPadByte(values) {
-        if (!Array.isArray(values) || !this.maxLength || !this.padByte) {
+        const maxLength = this.maxLength ?? this.maxCharLength;
+        if (!Array.isArray(values) || !maxLength || !this.padByte) {
             return values;
         }
 
@@ -162,8 +163,8 @@ class ValueRepresentation {
 
             // If the last element exceeds the max length by exactly one character and ends with the padding byte,
             // trim the padding byte to avoid a max length violation during write.
-            if (lastValue.length === this.maxLength + 1 && lastValue.endsWith(padChar)) {
-                values[lastIdx] = lastValue.substring(0, this.maxLength); // Trim the padding byte
+            if (lastValue.length === maxLength + 1 && lastValue.endsWith(padChar)) {
+                values[lastIdx] = lastValue.substring(0, maxLength); // Trim the padding byte
             }
         }
 
@@ -353,10 +354,6 @@ class AsciiStringRepresentation extends ValueRepresentation {
 
     readBytes(stream, length) {
         return stream.readAsciiString(length);
-    }
-
-    applyFormatting(value) {
-        return value.trim();
     }
 
     writeBytes(stream, value, writeOptions) {

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -161,10 +161,9 @@ class ValueRepresentation {
             const lastIdx = values.length - 1;
             const lastValue = values[lastIdx];
 
-            // If the last element exceeds the max length by exactly one character and ends with the padding byte,
-            // trim the padding byte to avoid a max length violation during write.
-            if (lastValue.length === maxLength + 1 && lastValue.endsWith(padChar)) {
-                values[lastIdx] = lastValue.substring(0, maxLength); // Trim the padding byte
+            // If the last element is odd and ends with the padding byte trim to avoid potential max length violations during write
+            if (lastValue.length % 2 !== 0 && lastValue.endsWith(padChar)) {
+                values[lastIdx] = lastValue.substring(0, lastValue.length - 1); // Trim the padding byte
             }
         }
 

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1158,7 +1158,7 @@ describe("test_un_vr", () => {
                 '00041130',
                 'CS',
                 new Uint8Array([0x4F, 0x52, 0x49, 0x47, 0x49, 0x4E, 0x41, 0x4C, 0x20, 0x20, 0x5C, 0x20, 0x50, 0x52, 0x49, 0x4D, 0x41, 0x52, 0x59, 0x20]).buffer,
-                ["ORIGINAL  ", " PRIMARY "],
+                ["ORIGINAL  ", " PRIMARY"],
                 ["ORIGINAL", "PRIMARY"]
             ],
             [

--- a/test/lossless-read-write.test.js
+++ b/test/lossless-read-write.test.js
@@ -2,11 +2,11 @@ import "regenerator-runtime/runtime.js";
 
 import fs from "fs";
 import dcmjs from "../src/index.js";
-import {deepEqual} from "../src/utilities/deepEqual";
+import { deepEqual } from "../src/utilities/deepEqual";
 
-import {getTestDataset} from "./testUtils";
+import { getTestDataset } from "./testUtils";
 
-const {DicomDict, DicomMessage} = dcmjs.data;
+const { DicomDict, DicomMessage } = dcmjs.data;
 
 
 describe('lossless-read-write', () => {
@@ -192,21 +192,6 @@ describe('lossless-read-write', () => {
         expect(deepEqual(expectedDataset, outputDicomDictPass2.dict)).toBeTruthy();
     });
 
-    test('test DA with multiplicity > 1 and added space for even padding is read and written correctly', () => {
-        const dataset = {
-            '00081160': {
-                vr: 'DA',
-                Value: ["20140601", "20140601 "],
-            }
-        };
-
-        const dicomDict = new DicomDict({});
-        dicomDict.dict = dataset;
-
-        // write and re-read
-        const outputDicomDict = DicomMessage.readFile(dicomDict.write());
-    });
-
     describe('Multiplicity for non-binary String VRs', () => {
         const maxLengthCases = [
             {
@@ -249,6 +234,27 @@ describe('lossless-read-write', () => {
                 Value: [123456789012, 123456789012],
                 _rawValue: ["123456789012", "123456789012"]
             },
+            {
+                vr: 'LO',
+                Value: ["ABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOP", "ABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOP"],
+                _rawValue: ["ABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOP", "ABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOPQRSTUVWXABCDEFGHIJKLMNOP"]
+            },
+            {
+                vr: 'SH',
+                Value: ["ABCDEFGHIJKLMNOP", "ABCDEFGHIJKLMNOP"],
+                _rawValue: ["ABCDEFGHIJKLMNOP", "ABCDEFGHIJKLMNOP"]
+            },
+            {
+                vr: 'UI',
+                Value: ["1.2.840.12345678901234567890123456789012345678901234567890123456", "1.2.840.12345678901234567890123456789012345678901234567890123456"],
+                _rawValue: ["1.2.840.12345678901234567890123456789012345678901234567890123456", "1.2.840.12345678901234567890123456789012345678901234567890123456"]
+            },
+            {
+                vr: 'TM',
+                Value: ["142530.1234567", "142530.1234567"],
+                _rawValue: ["142530.1234567", "142530.1234567"],
+            },
+
         ];
 
         test.each(maxLengthCases)(
@@ -274,7 +280,7 @@ describe('lossless-read-write', () => {
                     }
                 };
 
-                expect(expectedDataset).toEqual(outputDicomDict.dict);
+                expect(outputDicomDict.dict).toEqual(expectedDataset);
 
                 // re-write should succeed without max length issues
                 const outputDicomDictPass2 = DicomMessage.readFile(outputDicomDict.write());

--- a/test/lossless-read-write.test.js
+++ b/test/lossless-read-write.test.js
@@ -128,6 +128,70 @@ describe('lossless-read-write', () => {
         expect(outputDicomDict.dict['00181041'].Value).toEqual([9007199254740992])
     });
 
+    test('test DS with multiplicity > 1 and added space for even padding is read and written correctly', () => {
+        const dataset = {
+            '00200037': {
+                vr: 'DS',
+                Value: [0.99924236548978, -0.0322633220972, -0.0217663285287, 0.02949870928067, 0.99267261121054, -0.1171789789306]
+            }
+        };
+
+        const dicomDict = new DicomDict({});
+        dicomDict.dict = dataset;
+
+        // write and re-read
+        const outputDicomDict = DicomMessage.readFile(dicomDict.write());
+
+        // ensure _rawValue strings have no added trailing spaces
+        const expectedDataset = {
+            '00200037': {
+                vr: 'DS',
+                Value: [0.99924236548978, -0.0322633220972, -0.0217663285287, 0.02949870928067, 0.99267261121054, -0.1171789789306],
+                _rawValue: ["0.99924236548978", "-0.0322633220972", "-0.0217663285287", "0.02949870928067", "0.99267261121054", "-0.1171789789306"]
+            }
+        };
+
+        expect(deepEqual(expectedDataset, outputDicomDict.dict)).toBeTruthy();
+
+        // re-write should succeeed
+        const outputDicomDictPass2 = DicomMessage.readFile(dicomDict.write());
+
+        // dataset should still be equal
+        expect(deepEqual(expectedDataset, outputDicomDictPass2.dict)).toBeTruthy();
+    });
+
+    test('test IS with multiplicity > 1 and added space for even padding is read and written correctly', () => {
+        const dataset = {
+            '00081160': {
+                vr: 'IS',
+                Value: [1234, 5678]
+            }
+        };
+
+        const dicomDict = new DicomDict({});
+        dicomDict.dict = dataset;
+
+        // write and re-read
+        const outputDicomDict = DicomMessage.readFile(dicomDict.write());
+
+        // ensure _rawValue strings have no added trailing spaces
+        const expectedDataset = {
+            '00081160': {
+                vr: 'IS',
+                Value: [1234, 5678],
+                _rawValue: ["1234", "5678 "]
+            }
+        };
+
+        expect(deepEqual(expectedDataset, outputDicomDict.dict)).toBeTruthy();
+
+        // re-write should succeeed
+        const outputDicomDictPass2 = DicomMessage.readFile(dicomDict.write());
+
+        // dataset should still be equal
+        expect(deepEqual(expectedDataset, outputDicomDictPass2.dict)).toBeTruthy();
+    });
+
     describe('Individual VR comparisons', () => {
 
         const unchangedTestCases = [


### PR DESCRIPTION
Fixes issue during lossless read/write with numeric string value representations (`IS`/`DS`). This was caused by a string like:
`0.99924236548978\-0.0322633220972\-0.0217663285287\0.02949870928067\0.99267261121054\-0.1171789789306 ` where the space following the final number is correctly added for evenness, but produced an error during re-write as the unformatted value exceeded the max length of the VR.

Solution was to remove this padding byte from `_rawValue` property during read if it exceeds the max length of the vr. This padding will be re-added by the writer if needed for evenness. 