### PR TITLE
feat(vr): Save original non-standard VR

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -126,6 +126,10 @@ class DicomMetaDictionary {
                     // when the vr is data-dependent, keep track of the original type
                     naturalDataset._vrMap[naturalName] = data.vr;
                 }
+                if (data.vr !== entry.vr) {
+                    // save origin vr if it different that in dictionary
+                    naturalDataset._vrMap[naturalName] = data.vr;
+                }
             }
 
             if (data.Value === undefined) {
@@ -217,9 +221,13 @@ class DicomMetaDictionary {
                     return;
                 }
                 // process this one entry
-                var dataItem = ValueRepresentation.addTagAccessors({
-                    vr: entry.vr
-                });
+                const vr =
+                    dataset._vrMap && dataset._vrMap[naturalName]
+                        ? dataset._vrMap[naturalName]
+                        : entry.vr;
+
+                var dataItem = ValueRepresentation.addTagAccessors({ vr });
+
                 dataItem.Value = dataset[naturalName];
 
                 if (dataValue !== null) {


### PR DESCRIPTION
Hello, I encountered several issues with saving the dataset to a file. 
After investigation I found that the source file has different vr that  in dictionary And the main problem is that after the `naturalizeDataset` process we lose origin vr for these tags and in the `denaturalizeDataset `process we try to process tag with incorrect vr 
and therefore we get the following errors when trying to write.

![image](https://github.com/user-attachments/assets/99cdebc3-2f7c-41a4-8afb-0d5bc9426821)

In dicom image (LUTData tag has incorrect vr. In standart it US)

![Screenshot from 2024-12-18 15-09-51](https://github.com/user-attachments/assets/6a01ac01-eab7-4889-b88b-72d0632ae399)

We received that image and we get the following errors when trying to write

![Screenshot from 2024-12-18 12-23-12](https://github.com/user-attachments/assets/afc00479-c52c-4614-ac27-df1ff934eb26)
