### PR TITLE
fix(build): Fix assert failure in rollup

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,7 +6,7 @@ import commonjs from "@rollup/plugin-commonjs";
 // import babelRuntime from "@rollup/plugin-transform-runtime"
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 export default {
     input: "src/index.js",


### PR DESCRIPTION
Due to change in nodejs, as described here:

https://github.com/rollup/rollup/issues/5531

Before this fix:
```
% npm run build

> dcmjs@0.30.0 build
> rollup -c

[!] SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:338:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:102:18)
    at ModuleLoader.#translate (node:internal/modules/esm/loader:437:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:484:27)
    at ModuleJob._link (node:internal/modules/esm/module_job:115:19)

```