### PR TITLE
Preserve optional DICOM SegmentDescription during renumbering

### DIFF
--- a/src/derivations/Segmentation.js
+++ b/src/derivations/Segmentation.js
@@ -414,6 +414,11 @@ export default class Segmentation extends DerivedPixels {
                 Segment.SegmentedPropertyTypeCodeSequence
         };
 
+        if (Segment.SegmentDescription) {
+            reNumberedSegmentCopy.SegmentDescription =
+                Segment.SegmentDescription;
+        }
+
         if (
             SegmentAlgorithmType === "AUTOMATIC" ||
             SegmentAlgorithmType === "SEMIAUTOMATIC"


### PR DESCRIPTION
This pull request adds support for handling the optional DICOM SegmentDescription field during segment renumbering. If the source segment includes a SegmentDescription, it will be copied to the renumbered segment.