### PR TITLE
fix(dicomMessage): to handle undefined return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "rollup -c",
     "build:examples": "npm run build && npx cpx 'build/**/*.{js,map}' examples/js",
     "start": "rollup -c -w",
+    "dev": "rollup -c -w",
     "format": "prettier --write 'src/**/*.js' 'test/**/*.js'",
     "format:check": "prettier --check 'src/**/*.js' 'test/**/*.js'",
     "lint": "eslint --fix 'src/**/*.js' 'test/**/*.js'"

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -378,12 +378,8 @@ class DicomMessage {
                 values.push(value);
             }
         } else {
-            const { rawValue, value } = vr.read(
-                stream,
-                length,
-                syntax,
-                options
-            ) || {};
+            const { rawValue, value } =
+                vr.read(stream, length, syntax, options) || {};
             if (!vr.isBinary() && singleVRs.indexOf(vr.type) == -1) {
                 rawValues = rawValue;
                 values = value;

--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -383,7 +383,7 @@ class DicomMessage {
                 length,
                 syntax,
                 options
-            );
+            ) || {};
             if (!vr.isBinary() && singleVRs.indexOf(vr.type) == -1) {
                 rawValues = rawValue;
                 values = value;


### PR DESCRIPTION
I have some data that fails to load in OHIF when draged and dropped ([try](https://viewer-dev.ohif.org/localbasic) ), and i have narrowed down the issue to an undefined value which this PR fixes

Here is the issue which has the data attached

https://github.com/OHIF/Viewers/issues/4588#issuecomment-2598032763

--

At OHIF, we use namify, and apparently, this data contains some undefined values that need to be addressed during the process.