### PR TITLE
Updated README to include dcmjs-codecs library

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ _Parts of DICOM that dcmjs *will not* focus on:_
 - DIMSE (legacy networking like C-STORE, C-FIND, C-MOVE, etc). See the [dcmjs-dimse](https://github.com/PantelisGeorgiadis/dcmjs-dimse) project for that.
 - Physical Media (optical disks). See [this FAQ](https://www.dclunie.com/medical-image-faq/html/index.html) if you need to work with those.
 - Image rendering. See [dcmjs-imaging](https://github.com/PantelisGeorgiadis/dcmjs-imaging) for this.
+- Encapsulated transfer syntax transcoding. See [dcmjs-codecs](https://github.com/PantelisGeorgiadis/dcmjs-codecs) for this.
 - 3D rendering.  See [vtk.js](https://kitware.github.io/vtk-js/index.html).
 - Radiology review application - see [OHIF](https://ohif.org).
 


### PR DESCRIPTION
Added link to [dcmjs-codecs](https://github.com/PantelisGeorgiadis/dcmjs-codecs) library which facilitates encapsulated dataset and part10 file transcoding among all major transfer syntaxes.