### PR TITLE
fix(value-representation): prevent truncation of DA, DT, and TM in denormalization

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -270,11 +270,19 @@ class DicomMetaDictionary {
 
                     if (!vr.isBinary() && vr.maxLength) {
                         dataItem.Value = dataItem.Value.map(value => {
-                            if (value.length > vr.maxLength) {
+                            let maxLength = vr.maxLength;
+                            if (
+                                vr.allowRangeMatching() &&
+                                vr.rangeMatchingMaxLength != null
+                            ) {
+                                maxLength = vr.rangeMatchingMaxLength;
+                            }
+
+                            if (value.length > maxLength) {
                                 log.warn(
-                                    `Truncating value ${value} of ${naturalName} because it is longer than ${vr.maxLength}`
+                                    `Truncating value ${value} of ${naturalName} because it is longer than ${maxLength}`
                                 );
-                                return value.slice(0, vr.maxLength);
+                                return value.slice(0, maxLength);
                             } else {
                                 return value;
                             }

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -545,6 +545,69 @@ it("test_custom_dictionary", () => {
     expect(Object.keys(dataset).length).toEqual(17);
 });
 
+it("test_code_string_vr_truncated", () => {
+    // Create a dataset with a CS value that exceeds the 16-character limit and gets truncated
+    const testDataset = {
+        Modality: "MAGNETICRESONANCE"
+    };
+
+    const denaturalizedDataset =
+        DicomMetaDictionary.denaturalizeDataset(testDataset);
+
+    expect(denaturalizedDataset["00080060"].vr).toEqual("CS");
+    expect(denaturalizedDataset["00080060"].Value[0]).toEqual(
+        "MAGNETICRESONANC"
+    );
+});
+
+it("test_date_time_vr_range_matching_not_truncated", () => {
+    // Create a dataset with DT (DateTime) value representation with range matching
+    const testDataset = {
+        // 2023-01-31 08:30 AM to 09:00 AM UTC
+        DateTime: "20230131083000.000+0000-20230131090000.000+0000"
+    };
+
+    const denaturalizedDataset =
+        DicomMetaDictionary.denaturalizeDataset(testDataset);
+
+    expect(denaturalizedDataset["0040A120"].vr).toEqual("DT");
+    expect(denaturalizedDataset["0040A120"].Value[0]).toEqual(
+        "20230131083000.000+0000-20230131090000.000+0000"
+    );
+});
+
+it("test_date_vr_range_matching_not_truncated", () => {
+    // Create a dataset with DA (Date) value representation with range matching
+    const testDataset = {
+        // January 1, 2023 to March 1, 2023
+        StudyDate: "20230101-20230301"
+    };
+
+    const denaturalizedDataset =
+        DicomMetaDictionary.denaturalizeDataset(testDataset);
+
+    expect(denaturalizedDataset["00080020"].vr).toEqual("DA");
+    expect(denaturalizedDataset["00080020"].Value[0]).toEqual(
+        "20230101-20230301"
+    );
+});
+
+it("test_time_range_matching_attribute_not_truncated", () => {
+    // Create a dataset with TM (Time) value representation with range matching
+    const testDataset = {
+        // 08:00 AM to 02:30 PM
+        StudyTime: "080000.000-143000.000"
+    };
+
+    const denaturalizedDataset =
+        DicomMetaDictionary.denaturalizeDataset(testDataset);
+
+    expect(denaturalizedDataset["00080030"].vr).toEqual("TM");
+    expect(denaturalizedDataset["00080030"].Value[0]).toEqual(
+        "080000.000-143000.000"
+    );
+});
+
 it("Reads DICOM with multiplicity", async () => {
     const url =
         "https://github.com/dcmjs-org/data/releases/download/multiplicity/multiplicity.dcm";


### PR DESCRIPTION
### Follow-up to [#426](https://github.com/dcmjs-org/dcmjs/pull/426)  

This PR addresses the following:  

- Reverts changes related to `writeBytes` for `DA`, `DT`, and `TM`.  
- Adds `allowRangeMatching` to the `ValueRepresentation` class to indicate whether a VR supports range matching.  
- Updates the truncation logic in `denaturalizeDataset`:  
  - If `vr.allowRangeMatching()` and `vr.rangeMatchingMaxLength` return `true`, `maxLength` is set to `vr.rangeMatchingMaxLength`. 