### PR TITLE
fix(datasetToBlob): Allow dataset._meta to be omitted

### DIFF
--- a/src/datasetToBlob.js
+++ b/src/datasetToBlob.js
@@ -6,11 +6,7 @@ function datasetToDict(dataset) {
     fileMetaInformationVersionArray[1] = 1;
 
     const TransferSyntaxUID =
-        dataset._meta.TransferSyntaxUID &&
-        dataset._meta.TransferSyntaxUID.Value &&
-        dataset._meta.TransferSyntaxUID.Value[0]
-            ? dataset._meta.TransferSyntaxUID.Value[0]
-            : "1.2.840.10008.1.2.1";
+        dataset._meta?.TransferSyntaxUID?.Value?.[0] ?? "1.2.840.10008.1.2.1";
 
     dataset._meta = {
         MediaStorageSOPClassUID: dataset.SOPClassUID,


### PR DESCRIPTION
Without this it is necessary to add report.dataset._meta = {} before you can write a derived dataset like StructuredReport to part10 format:

    const obj = await readFile("obj.dcm");
    const dicom_data = dcmjs.data.DicomMessage.readFile(obj.buffer);
    const report = new dcmjs.derivations.StructuredReport([dicom_data]);
    report.dataset._meta = {}; // <-- Fix the need for this!
    const buffer = dcmjs.data.datasetToDict(report.dataset).write();