### PR TITLE
feat: add text box group to TID300 measurements

### DIFF
--- a/src/utilities/TID300/TID300Measurement.js
+++ b/src/utilities/TID300/TID300Measurement.js
@@ -12,8 +12,40 @@ export default class TID300Measurement {
             ...this.getTrackingGroups(),
             ...this.getFindingGroup(),
             ...this.getFindingSiteGroups(),
-            ...contentSequenceEntries
+            ...contentSequenceEntries,
+            ...this.getTextBoxGroups()
         ];
+    }
+
+    getTextBoxGroups() {
+        const { textBoxPoint } = this.props;
+
+        if (
+            !textBoxPoint ||
+            typeof textBoxPoint.x !== "number" ||
+            typeof textBoxPoint.y !== "number"
+        ) {
+            return [];
+        }
+
+        const textBoxSequence = {
+            RelationshipType: "CONTAINS",
+            ValueType: "SCOORD",
+            ConceptNameCodeSequence: {
+                CodeValue: "111030",
+                CodingSchemeDesignator: "DCM",
+                CodeMeaning: "Annotation Position"
+            },
+            GraphicType: "POINT",
+            GraphicData: [textBoxPoint.x, textBoxPoint.y],
+            ContentSequence: {
+                RelationshipType: "SELECTED FROM",
+                ValueType: "IMAGE",
+                ReferencedSOPSequence: this.ReferencedSOPSequence
+            }
+        };
+
+        return [textBoxSequence];
     }
 
     getTrackingGroups() {


### PR DESCRIPTION
This PR adds the ability to store the position of a textbox or label within an SR.

With this enhancement, libraries such as OHIF and Cornerstone can save and reload the textbox positions that users manually set.

Currently, this isn't possible, as textbox positions are lost when saving the SR.