### PR TITLE
feat: Allow TID300 measurements to use either 2d or 3d points with SCOORD or SCOORD3D

### DIFF
--- a/src/utilities/TID1500/TID1500MeasurementReport.js
+++ b/src/utilities/TID1500/TID1500MeasurementReport.js
@@ -171,6 +171,10 @@ export default class TID1500MeasurementReport {
         // with the proper ReferencedSOPSequence
         TID1501MeasurementGroups.forEach(measurementGroup => {
             measurementGroup.TID300Measurements.forEach(measurement => {
+                if (!measurement.ReferencedSOPSequence) {
+                    return;
+                }
+
                 const { ReferencedSOPInstanceUID } =
                     measurement.ReferencedSOPSequence;
 

--- a/src/utilities/TID1500/TID1500MeasurementReport.js
+++ b/src/utilities/TID1500/TID1500MeasurementReport.js
@@ -171,10 +171,6 @@ export default class TID1500MeasurementReport {
         // with the proper ReferencedSOPSequence
         TID1501MeasurementGroups.forEach(measurementGroup => {
             measurementGroup.TID300Measurements.forEach(measurement => {
-                if (!measurement.ReferencedSOPSequence) {
-                    return;
-                }
-
                 const { ReferencedSOPInstanceUID } =
                     measurement.ReferencedSOPSequence;
 

--- a/src/utilities/TID300/Bidirectional.js
+++ b/src/utilities/TID300/Bidirectional.js
@@ -10,7 +10,8 @@ export default class Bidirectional extends TID300Measurement {
             shortAxisLength,
             unit,
             use3DSpatialCoordinates = false,
-            ReferencedSOPSequence
+            ReferencedSOPSequence,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const longAxisGraphicData = this.flattenPoints({
@@ -40,6 +41,9 @@ export default class Bidirectional extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData: longAxisGraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {
@@ -66,6 +70,9 @@ export default class Bidirectional extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData: shortAxisGraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Bidirectional.js
+++ b/src/utilities/TID300/Bidirectional.js
@@ -13,37 +13,14 @@ export default class Bidirectional extends TID300Measurement {
             ReferencedSOPSequence
         } = this.props;
 
-        const longAxisGraphicData = use3DSpatialCoordinates
-            ? [
-                  longAxis.point1.x,
-                  longAxis.point1.y,
-                  longAxis.point1.z,
-                  longAxis.point2.x,
-                  longAxis.point2.y,
-                  longAxis.point2.z
-              ]
-            : [
-                  longAxis.point1.x,
-                  longAxis.point1.y,
-                  longAxis.point2.x,
-                  longAxis.point2.y
-              ];
-
-        const shortAxisGraphicData = use3DSpatialCoordinates
-            ? [
-                  shortAxis.point1.x,
-                  shortAxis.point1.y,
-                  shortAxis.point1.z,
-                  shortAxis.point2.x,
-                  shortAxis.point2.y,
-                  shortAxis.point2.z
-              ]
-            : [
-                  shortAxis.point1.x,
-                  shortAxis.point1.y,
-                  shortAxis.point2.x,
-                  shortAxis.point2.y
-              ];
+        const longAxisGraphicData = this.flattenPoints({
+            points: [longAxis.point1, longAxis.point2],
+            use3DSpatialCoordinates
+        });
+        const shortAxisGraphicData = this.flattenPoints({
+            points: [shortAxis.point1, shortAxis.point2],
+            use3DSpatialCoordinates
+        });
 
         return this.getMeasurement([
             {

--- a/src/utilities/TID300/Bidirectional.js
+++ b/src/utilities/TID300/Bidirectional.js
@@ -9,8 +9,41 @@ export default class Bidirectional extends TID300Measurement {
             longAxisLength,
             shortAxisLength,
             unit,
+            use3DSpatialCoordinates = false,
             ReferencedSOPSequence
         } = this.props;
+
+        const longAxisGraphicData = use3DSpatialCoordinates
+            ? [
+                  longAxis.point1.x,
+                  longAxis.point1.y,
+                  longAxis.point1.z,
+                  longAxis.point2.x,
+                  longAxis.point2.y,
+                  longAxis.point2.z
+              ]
+            : [
+                  longAxis.point1.x,
+                  longAxis.point1.y,
+                  longAxis.point2.x,
+                  longAxis.point2.y
+              ];
+
+        const shortAxisGraphicData = use3DSpatialCoordinates
+            ? [
+                  shortAxis.point1.x,
+                  shortAxis.point1.y,
+                  shortAxis.point1.z,
+                  shortAxis.point2.x,
+                  shortAxis.point2.y,
+                  shortAxis.point2.z
+              ]
+            : [
+                  shortAxis.point1.x,
+                  shortAxis.point1.y,
+                  shortAxis.point2.x,
+                  shortAxis.point2.y
+              ];
 
         return this.getMeasurement([
             {
@@ -27,19 +60,16 @@ export default class Bidirectional extends TID300Measurement {
                 },
                 ContentSequence: {
                     RelationshipType: "INFERRED FROM",
-                    ValueType: "SCOORD",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
-                    GraphicData: [
-                        longAxis.point1.x,
-                        longAxis.point1.y,
-                        longAxis.point2.x,
-                        longAxis.point2.y
-                    ],
-                    ContentSequence: {
-                        RelationshipType: "SELECTED FROM",
-                        ValueType: "IMAGE",
-                        ReferencedSOPSequence
-                    }
+                    GraphicData: longAxisGraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
                 }
             },
             {
@@ -56,19 +86,16 @@ export default class Bidirectional extends TID300Measurement {
                 },
                 ContentSequence: {
                     RelationshipType: "INFERRED FROM",
-                    ValueType: "SCOORD",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
-                    GraphicData: [
-                        shortAxis.point1.x,
-                        shortAxis.point1.y,
-                        shortAxis.point2.x,
-                        shortAxis.point2.y
-                    ],
-                    ContentSequence: {
-                        RelationshipType: "SELECTED FROM",
-                        ValueType: "IMAGE",
-                        ReferencedSOPSequence
-                    }
+                    GraphicData: shortAxisGraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
                 }
             }
         ]);

--- a/src/utilities/TID300/Calibration.js
+++ b/src/utilities/TID300/Calibration.js
@@ -9,7 +9,8 @@ export default class Calibration extends TID300Measurement {
             unit = "mm",
             use3DSpatialCoordinates = false,
             distance,
-            ReferencedSOPSequence
+            ReferencedSOPSequence,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -35,6 +36,9 @@ export default class Calibration extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Calibration.js
+++ b/src/utilities/TID300/Calibration.js
@@ -12,9 +12,10 @@ export default class Calibration extends TID300Measurement {
             ReferencedSOPSequence
         } = this.props;
 
-        const GraphicData = use3DSpatialCoordinates
-            ? [point1.x, point1.y, point1.z, point2.x, point2.y, point2.z]
-            : [point1.x, point1.y, point2.x, point2.y];
+        const GraphicData = this.flattenPoints({
+            points: [point1, point2],
+            use3DSpatialCoordinates
+        });
 
         return this.getMeasurement([
             {

--- a/src/utilities/TID300/Calibration.js
+++ b/src/utilities/TID300/Calibration.js
@@ -7,9 +7,14 @@ export default class Calibration extends TID300Measurement {
             point1,
             point2,
             unit = "mm",
+            use3DSpatialCoordinates = false,
             distance,
             ReferencedSOPSequence
         } = this.props;
+
+        const GraphicData = use3DSpatialCoordinates
+            ? [point1.x, point1.y, point1.z, point2.x, point2.y, point2.z]
+            : [point1.x, point1.y, point2.x, point2.y];
 
         return this.getMeasurement([
             {
@@ -26,14 +31,16 @@ export default class Calibration extends TID300Measurement {
                 },
                 ContentSequence: {
                     RelationshipType: "INFERRED FROM",
-                    ValueType: "SCOORD",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
-                    GraphicData: [point1.x, point1.y, point2.x, point2.y],
-                    ContentSequence: {
-                        RelationshipType: "SELECTED FROM",
-                        ValueType: "IMAGE",
-                        ReferencedSOPSequence
-                    }
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
                 }
             }
         ]);

--- a/src/utilities/TID300/Circle.js
+++ b/src/utilities/TID300/Circle.js
@@ -1,28 +1,6 @@
 import TID300Measurement from "./TID300Measurement.js";
 import unit2CodingValue from "./unit2CodingValue.js";
 
-/**
- * Expand an array of points stored as objects into
- * a flattened array of points
- *
- * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
- * @param use3DSpatialCoordinates boolean: true for 3D points and false for 2D points.
- * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
- */
-function expandPoints(points, use3DSpatialCoordinates) {
-    const allPoints = [];
-
-    points.forEach(point => {
-        allPoints.push(point.x);
-        allPoints.push(point.y);
-        if (use3DSpatialCoordinates) {
-            allPoints.push(point.z);
-        }
-    });
-
-    return allPoints;
-}
-
 export default class Circle extends TID300Measurement {
     contentItem() {
         const {
@@ -39,7 +17,10 @@ export default class Circle extends TID300Measurement {
         // @ToDO The permiter has to be implemented
         // const reducer = (accumulator, currentValue) => accumulator + currentValue;
         // const perimeter = lengths.reduce(reducer);
-        const GraphicData = expandPoints(points, use3DSpatialCoordinates);
+        const GraphicData = this.flattenPoints({
+            points,
+            use3DSpatialCoordinates
+        });
 
         // TODO: Add Mean and STDev value of (modality?) pixels
 

--- a/src/utilities/TID300/Circle.js
+++ b/src/utilities/TID300/Circle.js
@@ -6,14 +6,18 @@ import unit2CodingValue from "./unit2CodingValue.js";
  * a flattened array of points
  *
  * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
+ * @param use3DSpatialCoordinates boolean: true for 3D points and false for 2D points.
  * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
  */
-function expandPoints(points) {
+function expandPoints(points, use3DSpatialCoordinates) {
     const allPoints = [];
 
     points.forEach(point => {
         allPoints.push(point.x);
         allPoints.push(point.y);
+        if (use3DSpatialCoordinates) {
+            allPoints.push(point.z);
+        }
     });
 
     return allPoints;
@@ -35,7 +39,7 @@ export default class Circle extends TID300Measurement {
         // @ToDO The permiter has to be implemented
         // const reducer = (accumulator, currentValue) => accumulator + currentValue;
         // const perimeter = lengths.reduce(reducer);
-        const GraphicData = expandPoints(points);
+        const GraphicData = expandPoints(points, use3DSpatialCoordinates);
 
         // TODO: Add Mean and STDev value of (modality?) pixels
 

--- a/src/utilities/TID300/Circle.js
+++ b/src/utilities/TID300/Circle.js
@@ -10,7 +10,8 @@ export default class Circle extends TID300Measurement {
             perimeter,
             area,
             areaUnit = "mm2",
-            unit = "mm"
+            unit = "mm",
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         // Combine all lengths to save the perimeter
@@ -42,6 +43,9 @@ export default class Circle extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "CIRCLE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/CobbAngle.js
+++ b/src/utilities/TID300/CobbAngle.js
@@ -8,8 +8,35 @@ export default class CobbAngle extends TID300Measurement {
             point3,
             point4,
             rAngle,
+            use3DSpatialCoordinates,
             ReferencedSOPSequence
         } = this.props;
+
+        const GraphicData = use3DSpatialCoordinates
+            ? [
+                  point1.x,
+                  point1.y,
+                  point1.z,
+                  point2.x,
+                  point2.y,
+                  point2.z,
+                  point3.x,
+                  point3.y,
+                  point3.z,
+                  point4.x,
+                  point4.y,
+                  point4.z
+              ]
+            : [
+                  point1.x,
+                  point1.y,
+                  point2.x,
+                  point2.y,
+                  point3.x,
+                  point3.y,
+                  point4.x,
+                  point4.y
+              ];
 
         return this.getMeasurement([
             {
@@ -31,23 +58,16 @@ export default class CobbAngle extends TID300Measurement {
                 },
                 ContentSequence: {
                     RelationshipType: "INFERRED FROM",
-                    ValueType: "SCOORD",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
-                    GraphicData: [
-                        point1.x,
-                        point1.y,
-                        point2.x,
-                        point2.y,
-                        point3.x,
-                        point3.y,
-                        point4.x,
-                        point4.y
-                    ],
-                    ContentSequence: {
-                        RelationshipType: "SELECTED FROM",
-                        ValueType: "IMAGE",
-                        ReferencedSOPSequence
-                    }
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
                 }
             }
         ]);

--- a/src/utilities/TID300/CobbAngle.js
+++ b/src/utilities/TID300/CobbAngle.js
@@ -12,31 +12,10 @@ export default class CobbAngle extends TID300Measurement {
             ReferencedSOPSequence
         } = this.props;
 
-        const GraphicData = use3DSpatialCoordinates
-            ? [
-                  point1.x,
-                  point1.y,
-                  point1.z,
-                  point2.x,
-                  point2.y,
-                  point2.z,
-                  point3.x,
-                  point3.y,
-                  point3.z,
-                  point4.x,
-                  point4.y,
-                  point4.z
-              ]
-            : [
-                  point1.x,
-                  point1.y,
-                  point2.x,
-                  point2.y,
-                  point3.x,
-                  point3.y,
-                  point4.x,
-                  point4.y
-              ];
+        const GraphicData = this.flattenPoints({
+            points: [point1, point2, point3, point4],
+            use3DSpatialCoordinates
+        });
 
         return this.getMeasurement([
             {

--- a/src/utilities/TID300/CobbAngle.js
+++ b/src/utilities/TID300/CobbAngle.js
@@ -9,7 +9,8 @@ export default class CobbAngle extends TID300Measurement {
             point4,
             rAngle,
             use3DSpatialCoordinates,
-            ReferencedSOPSequence
+            ReferencedSOPSequence,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -40,6 +41,9 @@ export default class CobbAngle extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Ellipse.js
+++ b/src/utilities/TID300/Ellipse.js
@@ -8,7 +8,8 @@ export default class Ellipse extends TID300Measurement {
             use3DSpatialCoordinates = false,
             ReferencedSOPSequence,
             area,
-            areaUnit
+            areaUnit,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -34,6 +35,9 @@ export default class Ellipse extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "ELLIPSE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Ellipse.js
+++ b/src/utilities/TID300/Ellipse.js
@@ -5,15 +5,19 @@ import unit2CodingValue from "./unit2CodingValue.js";
  * Expand an array of points stored as objects into
  * a flattened array of points
  *
- * @param points
+ * @param params.points
+ * @param params.use3DSpatialCoordinates indicates if it's 3D coordinates or not
  * @return {Array}
  */
-function expandPoints(points) {
+function expandPoints({ points, use3DSpatialCoordinates }) {
     const allPoints = [];
 
     points.forEach(point => {
         allPoints.push(point.x);
         allPoints.push(point.y);
+        if (use3DSpatialCoordinates) {
+            allPoints.push(point.z);
+        }
     });
 
     return allPoints;
@@ -21,9 +25,15 @@ function expandPoints(points) {
 
 export default class Ellipse extends TID300Measurement {
     contentItem() {
-        const { points, ReferencedSOPSequence, area, areaUnit } = this.props;
+        const {
+            points,
+            use3DSpatialCoordinates = false,
+            ReferencedSOPSequence,
+            area,
+            areaUnit
+        } = this.props;
 
-        const GraphicData = expandPoints(points);
+        const GraphicData = expandPoints({ points, use3DSpatialCoordinates });
 
         return this.getMeasurement([
             {
@@ -40,14 +50,16 @@ export default class Ellipse extends TID300Measurement {
                 },
                 ContentSequence: {
                     RelationshipType: "INFERRED FROM",
-                    ValueType: "SCOORD",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "ELLIPSE",
                     GraphicData,
-                    ContentSequence: {
-                        RelationshipType: "SELECTED FROM",
-                        ValueType: "IMAGE",
-                        ReferencedSOPSequence
-                    }
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
                 }
             }
         ]);

--- a/src/utilities/TID300/Ellipse.js
+++ b/src/utilities/TID300/Ellipse.js
@@ -1,28 +1,6 @@
 import TID300Measurement from "./TID300Measurement.js";
 import unit2CodingValue from "./unit2CodingValue.js";
 
-/**
- * Expand an array of points stored as objects into
- * a flattened array of points
- *
- * @param params.points
- * @param params.use3DSpatialCoordinates indicates if it's 3D coordinates or not
- * @return {Array}
- */
-function expandPoints({ points, use3DSpatialCoordinates }) {
-    const allPoints = [];
-
-    points.forEach(point => {
-        allPoints.push(point.x);
-        allPoints.push(point.y);
-        if (use3DSpatialCoordinates) {
-            allPoints.push(point.z);
-        }
-    });
-
-    return allPoints;
-}
-
 export default class Ellipse extends TID300Measurement {
     contentItem() {
         const {
@@ -33,7 +11,10 @@ export default class Ellipse extends TID300Measurement {
             areaUnit
         } = this.props;
 
-        const GraphicData = expandPoints({ points, use3DSpatialCoordinates });
+        const GraphicData = this.flattenPoints({
+            points,
+            use3DSpatialCoordinates
+        });
 
         return this.getMeasurement([
             {

--- a/src/utilities/TID300/Length.js
+++ b/src/utilities/TID300/Length.js
@@ -12,9 +12,10 @@ export default class Length extends TID300Measurement {
             ReferencedSOPSequence
         } = this.props;
 
-        const GraphicData = use3DSpatialCoordinates
-            ? [point1.x, point1.y, point1.z, point2.x, point2.y, point2.z]
-            : [point1.x, point1.y, point2.x, point2.y];
+        const GraphicData = this.flattenPoints({
+            points: [point1, point2],
+            use3DSpatialCoordinates
+        });
 
         return this.getMeasurement([
             {

--- a/src/utilities/TID300/Length.js
+++ b/src/utilities/TID300/Length.js
@@ -7,9 +7,14 @@ export default class Length extends TID300Measurement {
             point1,
             point2,
             unit = "mm",
+            use3DSpatialCoordinates = false,
             distance,
             ReferencedSOPSequence
         } = this.props;
+
+        const GraphicData = use3DSpatialCoordinates
+            ? [point1.x, point1.y, point1.z, point2.x, point2.y, point2.z]
+            : [point1.x, point1.y, point2.x, point2.y];
 
         return this.getMeasurement([
             {
@@ -26,14 +31,16 @@ export default class Length extends TID300Measurement {
                 },
                 ContentSequence: {
                     RelationshipType: "INFERRED FROM",
-                    ValueType: "SCOORD",
+                    ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
-                    GraphicData: [point1.x, point1.y, point2.x, point2.y],
-                    ContentSequence: {
-                        RelationshipType: "SELECTED FROM",
-                        ValueType: "IMAGE",
-                        ReferencedSOPSequence
-                    }
+                    GraphicData,
+                    ContentSequence: use3DSpatialCoordinates
+                        ? undefined
+                        : {
+                              RelationshipType: "SELECTED FROM",
+                              ValueType: "IMAGE",
+                              ReferencedSOPSequence
+                          }
                 }
             }
         ]);

--- a/src/utilities/TID300/Length.js
+++ b/src/utilities/TID300/Length.js
@@ -9,7 +9,8 @@ export default class Length extends TID300Measurement {
             unit = "mm",
             use3DSpatialCoordinates = false,
             distance,
-            ReferencedSOPSequence
+            ReferencedSOPSequence,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -35,6 +36,9 @@ export default class Length extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -5,7 +5,8 @@ export default class Point extends TID300Measurement {
         const {
             points,
             ReferencedSOPSequence,
-            use3DSpatialCoordinates = false
+            use3DSpatialCoordinates = false,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -29,6 +30,9 @@ export default class Point extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POINT",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Point.js
+++ b/src/utilities/TID300/Point.js
@@ -8,15 +8,12 @@ export default class Point extends TID300Measurement {
             use3DSpatialCoordinates = false
         } = this.props;
 
-        const GraphicData = use3DSpatialCoordinates
-            ? [points[0].x, points[0].y, points[0].z]
-            : [points[0].x, points[0].y];
-        // Allow storing another point as part of an indicator showing a single point
-        if (points.length == 2) {
-            GraphicData.push(points[1].x);
-            GraphicData.push(points[1].y);
-            if (use3DSpatialCoordinates) GraphicData.push(points[1].z);
-        }
+        const GraphicData = this.flattenPoints({
+            // Allow storing another point as part of an indicator showing a single point
+            points: points.slice(0, 2),
+            use3DSpatialCoordinates
+        });
+
         return this.getMeasurement([
             {
                 RelationshipType: "CONTAINS",

--- a/src/utilities/TID300/Polygon.js
+++ b/src/utilities/TID300/Polygon.js
@@ -10,7 +10,8 @@ export default class Polygon extends TID300Measurement {
             area,
             areaUnit,
             ReferencedSOPSequence,
-            use3DSpatialCoordinates = false
+            use3DSpatialCoordinates = false,
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -36,6 +37,9 @@ export default class Polygon extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYGON",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {
@@ -62,6 +66,9 @@ export default class Polygon extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYGON",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Polygon.js
+++ b/src/utilities/TID300/Polygon.js
@@ -1,27 +1,6 @@
 import TID300Measurement from "./TID300Measurement.js";
 import unit2CodingValue from "./unit2CodingValue.js";
 
-/**
- * Expand an array of points stored as objects into
- * a flattened array of points
- *
- * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
- * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
- */
-function expandPoints(points) {
-    const allPoints = [];
-
-    points.forEach(point => {
-        allPoints.push(point[0]);
-        allPoints.push(point[1]);
-        if (point[2] !== undefined) {
-            allPoints.push(point[2]);
-        }
-    });
-
-    return allPoints;
-}
-
 export default class Polygon extends TID300Measurement {
     contentItem() {
         const {
@@ -34,7 +13,10 @@ export default class Polygon extends TID300Measurement {
             use3DSpatialCoordinates = false
         } = this.props;
 
-        const GraphicData = expandPoints(points);
+        const GraphicData = this.flattenPoints({
+            points,
+            use3DSpatialCoordinates
+        });
 
         return this.getMeasurement([
             {

--- a/src/utilities/TID300/Polyline.js
+++ b/src/utilities/TID300/Polyline.js
@@ -10,7 +10,8 @@ export default class Polyline extends TID300Measurement {
             ReferencedSOPSequence,
             use3DSpatialCoordinates = false,
             perimeter,
-            unit = "mm"
+            unit = "mm",
+            ReferencedFrameOfReferenceUID
         } = this.props;
 
         const GraphicData = this.flattenPoints({
@@ -37,6 +38,9 @@ export default class Polyline extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {
@@ -64,6 +68,9 @@ export default class Polyline extends TID300Measurement {
                     ValueType: use3DSpatialCoordinates ? "SCOORD3D" : "SCOORD",
                     GraphicType: "POLYLINE",
                     GraphicData,
+                    ReferencedFrameOfReferenceUID: use3DSpatialCoordinates
+                        ? ReferencedFrameOfReferenceUID
+                        : undefined,
                     ContentSequence: use3DSpatialCoordinates
                         ? undefined
                         : {

--- a/src/utilities/TID300/Polyline.js
+++ b/src/utilities/TID300/Polyline.js
@@ -1,27 +1,6 @@
 import TID300Measurement from "./TID300Measurement";
 import unit2CodingValue from "./unit2CodingValue";
 
-/**
- * Expand an array of points stored as objects into
- * a flattened array of points
- *
- * @param points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
- * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
- */
-function expandPoints(points) {
-    const allPoints = [];
-
-    points.forEach(point => {
-        allPoints.push(point[0] || point.x);
-        allPoints.push(point[1] || point.y);
-        if (point[2] !== undefined || point.z !== undefined) {
-            allPoints.push(point[2] || point.z);
-        }
-    });
-
-    return allPoints;
-}
-
 export default class Polyline extends TID300Measurement {
     contentItem() {
         const {
@@ -34,7 +13,10 @@ export default class Polyline extends TID300Measurement {
             unit = "mm"
         } = this.props;
 
-        const GraphicData = expandPoints(points);
+        const GraphicData = this.flattenPoints({
+            points,
+            use3DSpatialCoordinates
+        });
 
         // TODO: Add Mean and STDev value of (modality?) pixels
         return this.getMeasurement([

--- a/src/utilities/TID300/TID300Measurement.js
+++ b/src/utilities/TID300/TID300Measurement.js
@@ -92,4 +92,26 @@ export default class TID300Measurement {
             };
         });
     }
+
+    /**
+     * Expands an array of points stored as objects into a flattened array of points
+     *
+     * @param param.points [{x: 0, y: 1}, {x: 1, y: 2}] or [{x: 0, y: 1, z: 0}, {x: 1, y: 2, z: 0}]
+     * @param param.use3DSpatialCoordinates boolean: true for 3D points and false for 2D points.
+     *
+     * @return {Array} [point1x, point1y, point2x, point2y] or [point1x, point1y, point1z, point2x, point2y, point2z]
+     */
+    flattenPoints({ points, use3DSpatialCoordinates = false }) {
+        const flattenedCoordinates = [];
+
+        points.forEach(point => {
+            flattenedCoordinates.push(point[0] || point.x);
+            flattenedCoordinates.push(point[1] || point.y);
+            if (use3DSpatialCoordinates) {
+                flattenedCoordinates.push(point[2] || point.z);
+            }
+        });
+
+        return flattenedCoordinates;
+    }
 }


### PR DESCRIPTION
## TID.300 Measurement Update

TID.300 measurements can now be defined using either 2D or 3D points. This is controlled by the use of either `SCOORD` (2D) or `SCOORD3D` (3D) in the **Measurement Value Sequence**, as described in the TID.320 section of TID.300:  
🔗 [DICOM TID.320 Reference](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_320)

TID.1501 defines the reference information for the SCOORD3D points:
🔗 [DICOM TID.1501 Reference](https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_A.html#sect_TID_1501)

This pull request introduces support for selecting between `SCOORD` and `SCOORD3D` encodings in several TID.300 measurement types, including:

- Length  
- Bidirectional  
- Calibration  
- Cobb Angle  
- Ellipse  

This is achieved by allowing the adapter to specify a `use3DSpatialCoordinates` flag in the function definition.

> **Note:** The responsibility of interpreting the returned coordinates—i.e., determining whether `SCOORD` or `SCOORD3D` is used—falls on the consuming library. This can be done by checking which of the two types is present in the sequence.
