### PR TITLE
Using `checkLength` to determine max length for DA, DT, TM (Query with range matching)

### DIFF
--- a/src/DicomMetaDictionary.js
+++ b/src/DicomMetaDictionary.js
@@ -270,11 +270,16 @@ class DicomMetaDictionary {
 
                     if (!vr.isBinary() && vr.maxLength) {
                         dataItem.Value = dataItem.Value.map(value => {
-                            if (value.length > vr.maxLength) {
+                            let maxLength = vr.maxLength;
+                            if (vr.rangeMatchingMaxLength) {
+                                maxLength = vr.rangeMatchingMaxLength;
+                            }
+
+                            if (value.length > maxLength) {
                                 log.warn(
-                                    `Truncating value ${value} of ${naturalName} because it is longer than ${vr.maxLength}`
+                                    `Truncating value ${value} of ${naturalName} because it is longer than ${maxLength}`
                                 );
-                                return value.slice(0, vr.maxLength);
+                                return value.slice(0, maxLength);
                             } else {
                                 return value;
                             }

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -694,27 +694,21 @@ class DateValue extends AsciiStringRepresentation {
     constructor(value) {
         super("DA", value);
         this.maxLength = 8;
+        this.rangeMatchingMaxLength = 18;
         this.padByte = PADDING_SPACE;
         //this.fixed = true;
         this.defaultValue = "";
     }
 
-    writeBytes(stream, value, writeOptions = {}) {
-        // Check if this is a query with range matching (contains a hyphen)
-        const isRangeQuery = typeof value === "string" && value.includes("-");
-
-        // For query with range matching, temporarily adjust maxLength
-        const originalMaxLength = this.maxLength;
-        if (isRangeQuery) {
-            this.maxLength = 18;
+    checkLength(value) {
+        if (typeof value === "string" || value instanceof String) {
+            const isRangeQuery = value.includes("-");
+            return (
+                value.length <=
+                (isRangeQuery ? this.rangeMatchingMaxLength : this.maxLength)
+            );
         }
-
-        const result = super.writeBytes(stream, value, writeOptions);
-
-        // Restore original maxLength
-        this.maxLength = originalMaxLength;
-
-        return result;
+        return true;
     }
 }
 
@@ -796,25 +790,19 @@ class DateTime extends AsciiStringRepresentation {
     constructor() {
         super("DT");
         this.maxLength = 26;
+        this.rangeMatchingMaxLength = 54;
         this.padByte = PADDING_SPACE;
     }
 
-    writeBytes(stream, value, writeOptions = {}) {
-        // Check if this is a query with range matching (contains a hyphen)
-        const isRangeQuery = typeof value === "string" && value.includes("-");
-
-        // For range queries, temporarily adjust maxLength
-        const originalMaxLength = this.maxLength;
-        if (isRangeQuery) {
-            this.maxLength = 54;
+    checkLength(value) {
+        if (typeof value === "string" || value instanceof String) {
+            const isRangeQuery = value.includes("-");
+            return (
+                value.length <=
+                (isRangeQuery ? this.rangeMatchingMaxLength : this.maxLength)
+            );
         }
-
-        const result = super.writeBytes(stream, value, writeOptions);
-
-        // Restore original maxLength
-        this.maxLength = originalMaxLength;
-
-        return result;
+        return true;
     }
 }
 
@@ -1249,6 +1237,7 @@ class TimeValue extends AsciiStringRepresentation {
     constructor() {
         super("TM");
         this.maxLength = 16;
+        this.rangeMatchingMaxLength = 28;
         this.padByte = PADDING_SPACE;
     }
 
@@ -1260,22 +1249,15 @@ class TimeValue extends AsciiStringRepresentation {
         return rtrim(value);
     }
 
-    writeBytes(stream, value, writeOptions = {}) {
-        // Check if this is a query with range matching (contains a hyphen)
-        const isRangeQuery = typeof value === "string" && value.includes("-");
-
-        // For range queries, temporarily adjust maxLength
-        const originalMaxLength = this.maxLength;
-        if (isRangeQuery) {
-            this.maxLength = 28;
+    checkLength(value) {
+        if (typeof value === "string" || value instanceof String) {
+            const isRangeQuery = value.includes("-");
+            return (
+                value.length <=
+                (isRangeQuery ? this.rangeMatchingMaxLength : this.maxLength)
+            );
         }
-
-        const result = super.writeBytes(stream, value, writeOptions);
-
-        // Restore original maxLength
-        this.maxLength = originalMaxLength;
-
-        return result;
+        return true;
     }
 }
 

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -545,6 +545,68 @@ it("test_custom_dictionary", () => {
     expect(Object.keys(dataset).length).toEqual(17);
 });
 
+it("test_code_string_vr_truncated", () => {
+    // Create a dataset with a CS value that exceeds the 16-character limit and gets truncated
+    const testDataset = {
+        Modality: "MAGNETICRESONANCE"
+    };
+
+    const denaturalizedDataset =
+        DicomMetaDictionary.denaturalizeDataset(testDataset);
+
+    expect(denaturalizedDataset["00080060"].vr).toEqual("CS");
+    expect(denaturalizedDataset["00080060"].Value[0]).toEqual(
+        "MAGNETICRESONANC"
+    );
+});
+
+it("test_date_time_vr_range_matching_not_truncated", () => {
+    const dateTime = "20230131083000.000+0000-20230131090000.000+0000";
+    const studyDate = "20230101-20230301";
+    const studyTime = "080000.000-143000.000";
+    
+    const padIfRequired = value => {
+        return value.length & 1 ? value + " " : value;
+    };
+
+    // Create a dataset with DA, TM and DT value representations with range matching
+    const testDataset = {
+        // 2023-01-31 08:30 AM to 09:00 AM UTC
+        DateTime: dateTime,
+        // January 1, 2023 to March 1, 2023
+        StudyDate: studyDate,
+        // 08:00 AM to 02:30 PM
+        StudyTime: studyTime
+    };
+
+    // Roundtrip the dataset through denaturalization, naturalization and denaturalization
+    const dicomDict = new DicomDict({
+        TransferSynxtaxUID: EXPLICIT_LITTLE_ENDIAN
+    });
+    dicomDict.dict = DicomMetaDictionary.denaturalizeDataset(testDataset);
+    const part10Buffer = dicomDict.write();
+
+    const dicomData = dcmjs.data.DicomMessage.readFile(part10Buffer);
+    const dataset = dcmjs.data.DicomMetaDictionary.naturalizeDataset(
+        dicomData.dict
+    );
+
+    const denaturalizedDataset =
+        DicomMetaDictionary.denaturalizeDataset(dataset);
+
+    // Check the VR and values (pad if required)
+    expect(denaturalizedDataset["0040A120"].vr).toEqual("DT");
+    expect(denaturalizedDataset["0040A120"].Value[0]).toEqual(
+        padIfRequired(dateTime)
+    );
+    expect(denaturalizedDataset["00080020"].vr).toEqual("DA");
+    expect(denaturalizedDataset["00080020"].Value[0]).toEqual(
+        padIfRequired(studyDate)
+    );
+    expect(denaturalizedDataset["00080030"].vr).toEqual("TM");
+    expect(denaturalizedDataset["00080030"].Value[0]).toEqual(studyTime); // No padding because of 'applyFormatting'
+});
+
 it("Reads DICOM with multiplicity", async () => {
     const url =
         "https://github.com/dcmjs-org/data/releases/download/multiplicity/multiplicity.dcm";

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -564,7 +564,7 @@ it("test_date_time_vr_range_matching_not_truncated", () => {
     const dateTime = "20230131083000.000+0000-20230131090000.000+0000";
     const studyDate = "20230101-20230301";
     const studyTime = "080000.000-143000.000";
-    
+
     const padIfRequired = value => {
         return value.length & 1 ? value + " " : value;
     };


### PR DESCRIPTION
This PR patches the work of @mishijima on #427.

More specifically,
- Removes the allowRangeMatching because the existence of rangeMatchingMaxLength, for a VR, gives the same information.
- Uses the existing checkLength function for DA, TM and DT to determine a range query and return whether the length is valid or not.
- Updates the unit tests to perform a full roundtrip between the naturalized and denaturalized worlds.
- The build output was used with dcmjs-dimse to make sure that range queries are working as expected.

@pieper please review and if you approve and merge, please close #427 since it is redundant.