### PR TITLE
Update templates.js

### DIFF
--- a/src/sr/templates.js
+++ b/src/sr/templates.js
@@ -1553,7 +1553,7 @@ class AlgorithmIdentification extends Template {
 
 class TrackingIdentifier extends Template {
     constructor(options) {
-        super(options);
+        super();
         if (options.uid === undefined) {
             throw new Error("Option 'uid' is required for TrackingIdentifier.");
         }


### PR DESCRIPTION
Fix TrackingIdentifier super call

Change super(options) → super() to prevent the raw options object being injected into the sequence.

Closes #434