### PR TITLE
Updated failing github actions to use ubuntu-latest runner

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish-package:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: publish
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Updated failing actions to utilize ubuntu-latest because github removed ubuntu-20.04 runner on 2025-04-15. This resulted in the failing execution of the `tests` and `publish-package` actions, and consequently prevented new PRs from being published.