### PR TITLE
fix: Save/load large explicit encoding values

### DIFF
--- a/test/data.test.js
+++ b/test/data.test.js
@@ -456,6 +456,28 @@ it("test_invalid_vr_length", () => {
     }
 });
 
+it("test_long_explicit_vr", () => {
+    const contourData = [];
+    for (let i = 0; i < 65536; i++) {
+        counterData.push(i);
+    }
+
+    const dicomDict = new DicomDict({
+        TransferSynxtaxUID: EXPLICIT_LITTLE_ENDIAN
+    });
+
+    const natural = {
+        ContourData: contourData
+    };
+
+    dicomDict.dict = dicomMetaDictionary.denaturalizeDataset(natural);
+    const part10Buffer = dicomDict.write();
+    const dicomData = DicomMessage.readFile(part10Buffer);
+    const dataset = DicomMetaDictionary.naturalizeDataset(dicomData.dict);
+
+    expect(dataset.ContourData).toEqual(contourData);
+});
+
 it("test_encapsulation", async () => {
     const url =
         "https://github.com/dcmjs-org/data/releases/download/encapsulation/encapsulation.dcm";


### PR DESCRIPTION
When encoding large explicit value encoded tags like ContourData (VR DS), dcmjs needs to write the DICOM as VR UN, according to:
   https://dicom.nema.org/medical/dicom/current/output/chtml/part03/sect_C.8.8.6.html#para_23e73451-d6b6-436b-a13a-76d0e3b341b6

"If the Value Length of this Data Element exceeds 65534 bytes and an Explicit VR Transfer Syntax is used, then the Value Representation UN can be used for this Data Element. See PS3.5 Section 6.2.2."

This PR adds a unit test for this condition, with a contour data containing 64k elements (thus well over 64k for the representation of it), and adds the writing capability for this value.  The reading value for this was already handled correctly.