### PR TITLE
fix: add a missing await to an asynchronous call

### DIFF
--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -536,7 +536,7 @@ export class AsyncDicomReader {
      */
     async readRawBinary(tagInfo) {
         const { length } = tagInfo;
-        this._emitSplitValues(length);
+        await this._emitSplitValues(length);
     }
 
     isSequence(tagInfo) {


### PR DESCRIPTION
The `_emitSplitValues` function is asynchronous. Omitting the `await` can cause a failure because of the unresolved promise.