### PR TITLE
fix: Add a drain method to prevent too many store operations

### DIFF
--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -309,6 +309,7 @@ export class AsyncDicomReader {
      */
     async _emitSplitValues(length) {
         const { stream, listener } = this;
+        await listener.awaitDrain?.();
         const { maxFragmentSize } = this;
         let offset = 0;
         while (offset < length) {


### PR DESCRIPTION
This adds an optional `drain` callback for controlling back pressure.