### PR TITLE
feat: Support for VR type "UV" 

### DIFF
--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -757,7 +757,8 @@ export class AsyncDicomReader {
             values = ["ISO_IR 192"];
         }
 
-        values.forEach(value => listener.value(value));
+        const valuesForListener = Array.isArray(values) ? values : [values];
+        valuesForListener.forEach(value => listener.value(value));
         return values;
     }
 }

--- a/src/BufferStream.js
+++ b/src/BufferStream.js
@@ -156,6 +156,12 @@ export class BufferStream {
         return this.increment(4);
     }
 
+    writeBigUint64(value) {
+        this.checkSize(8);
+        this.view.setBigUint64(this.offset, value, this.isLittleEndian);
+        return this.increment(8);
+    }
+
     writeFloat(value) {
         this.checkSize(4);
         this.view.setFloat32(this.offset, toFloat(value), this.isLittleEndian);
@@ -185,6 +191,12 @@ export class BufferStream {
             this.view.setUint8(startOffset + i, charCode);
         }
         return this.increment(len);
+    }
+
+    readBigUint64() {
+        var val = this.view.getBigUint64(this.offset, this.isLittleEndian);
+        this.increment(8);
+        return val;
     }
 
     readUint32() {

--- a/src/SplitDataView.js
+++ b/src/SplitDataView.js
@@ -268,6 +268,11 @@ export default class SplitDataView {
         return view.getUint32(offset - viewOffset, isLittleEndian);
     }
 
+    getBigUint64(offset, isLittleEndian) {
+        const { view, viewOffset } = this.findView(offset, 8);
+        return view.getBigUint64(offset - viewOffset, isLittleEndian);
+    }
+
     getFloat32(offset, isLittleEndian) {
         const { view, viewOffset } = this.findView(offset, 4);
         return view.getFloat32(offset - viewOffset, isLittleEndian);
@@ -310,6 +315,14 @@ export default class SplitDataView {
     setUint32(offset, value, isLittleEndian) {
         const { view, viewOffset, writeCommit } = this.findView(offset, 4);
         view.setUint32(offset - viewOffset, value, isLittleEndian);
+        if (writeCommit) {
+            this.writeCommit(view, offset);
+        }
+    }
+
+    setBigUint64(offset, value, isLittleEndian) {
+        const { view, viewOffset, writeCommit } = this.findView(offset, 8);
+        view.setBigUint64(offset - viewOffset, value, isLittleEndian);
         if (writeCommit) {
             this.writeCommit(view, offset);
         }

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -66,7 +66,7 @@ function toWindows(inputArray, size) {
 let DicomMessage, Tag, DicomMetaDictionary;
 
 var binaryVRs = ["FL", "FD", "SL", "SS", "UL", "US", "AT"],
-    length32VRs = ["OB", "OW", "OF", "SQ", "UC", "UR", "UT", "UN", "OD"],
+    length32VRs = ["OB", "OW", "OF", "SQ", "UC", "UR", "UT", "UN", "OD", "UV"],
     singleVRs = ["SQ", "OF", "OW", "OB", "UN"];
 
 class ValueRepresentation {
@@ -1359,6 +1359,29 @@ class UnsignedLong extends ValueRepresentation {
     }
 }
 
+class Unsigned64BitVeryLong extends ValueRepresentation {
+    constructor() {
+        super("UV");
+        this.maxLength = 8;
+        this.padByte = PADDING_NULL;
+        this.fixed = true;
+        this.defaultValue = 0;
+    }
+
+    readBytes(stream) {
+        return stream.readBigUint64();
+    }
+
+    writeBytes(stream, value, writeOptions) {
+        return super.writeBytes(
+            stream,
+            value,
+            super.write(stream, "BigUint64", value),
+            writeOptions
+        );
+    }
+}
+
 class UniqueIdentifier extends AsciiStringRepresentation {
     constructor() {
         super("UI");
@@ -1527,7 +1550,8 @@ let VRinstances = {
     UN: new UnknownValue(),
     UR: new UniversalResource(),
     US: new UnsignedShort(),
-    UT: new UnlimitedText()
+    UT: new UnlimitedText(),
+    UV: new Unsigned64BitVeryLong()
 };
 
 export { ValueRepresentation };

--- a/src/ValueRepresentation.js
+++ b/src/ValueRepresentation.js
@@ -65,7 +65,7 @@ function toWindows(inputArray, size) {
 
 let DicomMessage, Tag, DicomMetaDictionary;
 
-var binaryVRs = ["FL", "FD", "SL", "SS", "UL", "US", "AT"],
+var binaryVRs = ["FL", "FD", "SL", "SS", "UL", "US", "AT", "UV"],
     length32VRs = ["OB", "OW", "OF", "SQ", "UC", "UR", "UT", "UN", "OD", "UV"],
     singleVRs = ["SQ", "OF", "OW", "OB", "UN"];
 

--- a/test/sync-async-parser-equivalency.test.js
+++ b/test/sync-async-parser-equivalency.test.js
@@ -5,10 +5,7 @@ const { AsyncDicomReader } = dcmjs.async;
 
 const EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1";
 const TEST_UV_TAG = "00111011";
-const TEST_UV_VALUES = [
-    BigInt("9007199254741992"),
-    BigInt("9007199254741993")
-];
+const TEST_UV_VALUES = [BigInt("9007199254741992"), BigInt("9007199254741993")];
 
 DicomDict.setDicomMessageClass(DicomMessage);
 

--- a/test/sync-async-parser-equivalency.test.js
+++ b/test/sync-async-parser-equivalency.test.js
@@ -1,0 +1,75 @@
+import dcmjs from "../src/index.js";
+
+const { DicomDict, DicomMessage } = dcmjs.data;
+const { AsyncDicomReader } = dcmjs.async;
+
+const EXPLICIT_LITTLE_ENDIAN = "1.2.840.10008.1.2.1";
+const TEST_UV_TAG = "00111011";
+const TEST_UV_VALUES = [
+    BigInt("9007199254741992"),
+    BigInt("9007199254741993")
+];
+
+DicomDict.setDicomMessageClass(DicomMessage);
+
+function toArrayBuffer(bufferLike) {
+    if (bufferLike instanceof ArrayBuffer) {
+        const copy = new ArrayBuffer(bufferLike.byteLength);
+        new Uint8Array(copy).set(new Uint8Array(bufferLike));
+        return copy;
+    }
+
+    const u8 = new Uint8Array(
+        bufferLike.buffer,
+        bufferLike.byteOffset,
+        bufferLike.byteLength
+    );
+    const copy = new ArrayBuffer(u8.length);
+    new Uint8Array(copy).set(u8);
+    return copy;
+}
+
+function createPart10WithUV() {
+    const dicomDict = new DicomDict({
+        "00020010": {
+            vr: "UI",
+            Value: [EXPLICIT_LITTLE_ENDIAN]
+        }
+    });
+
+    dicomDict.dict = {
+        [TEST_UV_TAG]: {
+            vr: "UV",
+            Value: TEST_UV_VALUES
+        }
+    };
+
+    return toArrayBuffer(dicomDict.write());
+}
+
+describe("sync and async parser equivalency tests", () => {
+    describe("UV containing Part 10", () => {
+        test("sync parser reads UV value into parsed object", () => {
+            const part10 = createPart10WithUV();
+            const parsed = DicomMessage.readFile(part10);
+
+            expect(parsed.dict[TEST_UV_TAG]).toBeDefined();
+            expect(parsed.dict[TEST_UV_TAG].vr).toBe("UV");
+            expect(parsed.dict[TEST_UV_TAG].Value).toEqual(TEST_UV_VALUES);
+        });
+
+        test("async parser reads UV value into parsed object", async () => {
+            const part10 = createPart10WithUV();
+            const reader = new AsyncDicomReader();
+
+            reader.stream.addBuffer(part10);
+            reader.stream.setComplete();
+
+            const parsed = await reader.readFile();
+
+            expect(parsed.dict[TEST_UV_TAG]).toBeDefined();
+            expect(parsed.dict[TEST_UV_TAG].vr).toBe("UV");
+            expect(parsed.dict[TEST_UV_TAG].Value).toEqual(TEST_UV_VALUES);
+        });
+    });
+});

--- a/test/writeBufferStream.test.js
+++ b/test/writeBufferStream.test.js
@@ -51,6 +51,21 @@ describe("WriteBufferStream Tests", () => {
         }
     });
 
+    it("writeBigUint64", () => {
+        const stream = new WriteBufferStream(25, true);
+        expect(stream).toBeDefined();
+        const expected = [];
+        for (let i = 0; i < 512; i++) {
+            expected[i] = BigInt(i) * BigInt("0x7fffffffffffff"); // 0x7fffffffffffff = (2^64 - 1) / 512
+            stream.writeBigUint64(expected[i]);
+        }
+        expect(stream.view.buffers.length).toBe(Math.ceil((512 * 8) / 25));
+        for (let i = 0; i < 512; i++) {
+            const actual = stream.view.getBigUint64(i * 8, stream.isLittleEndian);
+            expect(actual).toBe(expected[i]);
+        }
+    });
+
     it("writesLongStrings", () => {
         const stream = new WriteBufferStream(32, true);
         let string = "0";
@@ -74,6 +89,7 @@ describe("WriteBufferStream Tests", () => {
         out.writeInt16(-123);
         out.writeInt32(-234);
         out.writeInt8(-25);
+        out.writeBigUint64(BigInt(123456789));
         out.writeUint32(123);
         out.writeUint16(234);
         out.writeUint8(25);
@@ -91,6 +107,7 @@ describe("WriteBufferStream Tests", () => {
             expect(stream.readInt16()).toBe(-123);
             expect(stream.readInt32()).toBe(-234);
             expect(stream.readInt8()).toBe(-25);
+            expect(stream.readBigUint64()).toBe(BigInt(123456789));
             expect(stream.readUint32()).toBe(123);
             expect(stream.readUint16()).toBe(234);
             expect(stream.readUint8()).toBe(25);

--- a/test/writeBufferStream.test.js
+++ b/test/writeBufferStream.test.js
@@ -61,7 +61,10 @@ describe("WriteBufferStream Tests", () => {
         }
         expect(stream.view.buffers.length).toBe(Math.ceil((512 * 8) / 25));
         for (let i = 0; i < 512; i++) {
-            const actual = stream.view.getBigUint64(i * 8, stream.isLittleEndian);
+            const actual = stream.view.getBigUint64(
+                i * 8,
+                stream.isLittleEndian
+            );
             expect(actual).toBe(expected[i]);
         }
     });


### PR DESCRIPTION
In accordance with the (not so) new DICOM metadata standards, since 2019a, as stated in PS3.5, section 6.2 (see [here](https://dicom.nema.org/medical/dicom/2019a/output/chtml/part05/sect_6.2.html#para_570df2d2-ab6d-4bfa-b6cb-cad800e4596c)), the VR type "UV", or "Unsigned 64 bit Very Long" describes, as one would expect, a 64 bit unsigned integer.

To comply with these standards and avoid interpreting these values as VR type "UN" (Unknown), I offer this contribution.

I attempted to keep things as close to the standard you've set as I could, but, in case of any insatisfaction, I am more than capable of reworking the code herein suggested.

The tests leave quite a bit to be desired. I must admit testing is not my greatest strong suit. Basic testing is in place for reading and writing, but more in-depth tests with real DICOM datasets would be welcome.

I couldn't find any documentation as to how I should write the Pull Request, so I hope this is acceptable

(Also, my first Pull Request, so I ask you to forgive me if something here isn't up to standard)