### PR TITLE
fix(DicomMessage): parse UN-encoded sequences using Implicit VR LE per PS3.5 §6.2.2

### DIFF
--- a/src/DicomMessage.js
+++ b/src/DicomMessage.js
@@ -294,7 +294,8 @@ export class DicomMessage {
 
         var length = null,
             vr = null,
-            vrType;
+            vrType,
+            wireVrType = null; // VR as literally encoded in the stream (explicit mode)
 
         if (implicit) {
             length = stream.readUint32();
@@ -318,6 +319,7 @@ export class DicomMessage {
             vr = ValueRepresentation.createByTypeString(vrType);
         } else {
             vrType = stream.readVR();
+            wireVrType = vrType; // remember literal stream VR before any override
 
             if (
                 vrType === "UN" &&
@@ -339,6 +341,23 @@ export class DicomMessage {
             }
         }
 
+        // DICOM PS3.5 §6.2.2: a UN element with a defined length whose payload
+        // begins with the item-start delimiter (0xFFFE,E000 = FE FF 00 E0 in
+        // Little Endian) must be parsed as a Sequence using Implicit VR LE,
+        // regardless of the file's transfer syntax.
+        let readSyntax = syntax;
+        if (
+            wireVrType === "UN" &&
+            length > 0 &&
+            length !== UNDEFINED_LENGTH &&
+            stream.peekUint8(0) === 0xfe &&
+            stream.peekUint8(1) === 0xff
+        ) {
+            vrType = "SQ";
+            vr = ValueRepresentation.createByTypeString("SQ");
+            readSyntax = IMPLICIT_LITTLE_ENDIAN;
+        }
+
         var values = [];
         var rawValues = [];
         if (vr.isBinary() && length > vr.maxLength && !vr.noMultiple) {
@@ -348,7 +367,7 @@ export class DicomMessage {
                 const { rawValue, value } = vr.read(
                     stream,
                     vr.maxLength,
-                    syntax,
+                    readSyntax,
                     options
                 );
                 rawValues.push(rawValue);
@@ -356,7 +375,7 @@ export class DicomMessage {
             }
         } else {
             const { rawValue, value } =
-                vr.read(stream, length, syntax, options) || {};
+                vr.read(stream, length, readSyntax, options) || {};
             if (!vr.isBinary() && singleVRs.indexOf(vr.type) == -1) {
                 rawValues = rawValue;
                 values = value;

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1774,3 +1774,64 @@ describe("test OtherDouble ValueRepresentation", () => {
         expect(data.dict["00701B02"].Value[0]).toBe(1);
     });
 });
+
+// DICOM PS3.5 §6.2.2: an Explicit VR element encoded as UN with a defined
+// length must be parsed using Implicit VR Little Endian when its payload
+// begins with the item-start delimiter 0xFFFEE000.
+it("parses a UN-encoded sequence (VR=UN, defined length) using Implicit VR LE per PS3.5 §6.2.2", () => {
+    // ---------- build the item payload (Implicit VR LE) ----------
+    // Tag (0018,1009) UniqueDeviceIdentifier — 4 bytes LE
+    const udi = "*+B220INTUITION040/$$+7INTUITION4.10.1%*"; // 40 chars
+    const udiBytes = new Uint8Array(udi.length);
+    for (let i = 0; i < udi.length; i++) udiBytes[i] = udi.charCodeAt(i);
+
+    // item payload: tag (0018,1009) + 4-byte length + value
+    const itemPayload = new Uint8Array(4 + 4 + udi.length);
+    const ipView = new DataView(itemPayload.buffer);
+    ipView.setUint16(0, 0x0018, true); // group
+    ipView.setUint16(2, 0x1009, true); // element
+    ipView.setUint32(4, udi.length, true); // length
+    itemPayload.set(udiBytes, 8);
+
+    // ---------- wrap in an SQ item (Implicit VR LE item tags) ----------
+    // item start: (FFFE,E000) + 4-byte length
+    const itemBytes = new Uint8Array(4 + 4 + itemPayload.length);
+    const ibView = new DataView(itemBytes.buffer);
+    ibView.setUint16(0, 0xfffe, true); // group  → FE FF
+    ibView.setUint16(2, 0xe000, true); // element → 00 E0
+    ibView.setUint32(4, itemPayload.length, true);
+    itemBytes.set(itemPayload, 8);
+
+    // ---------- wrap as Explicit VR UN element ----------
+    // tag (0018,100A) UDISequence, VR="UN", 2 reserved bytes, 4-byte length
+    const unElement = new Uint8Array(4 + 2 + 2 + 4 + itemBytes.length);
+    const ueView = new DataView(unElement.buffer);
+    ueView.setUint16(0, 0x0018, true); // group
+    ueView.setUint16(2, 0x100a, true); // element
+    unElement[4] = 0x55; // 'U'
+    unElement[5] = 0x4e; // 'N'
+    ueView.setUint16(6, 0, true); // reserved
+    ueView.setUint32(8, itemBytes.length, true); // 4-byte length (UN uses 32-bit)
+    unElement.set(itemBytes, 12);
+
+    // ---------- parse ----------
+    const stream = new ReadBufferStream(unElement.buffer, true);
+    const result = DicomMessage._readTag(stream, EXPLICIT_LITTLE_ENDIAN);
+
+    // should have been promoted to SQ
+    expect(result.vr.type).toBe("SQ");
+
+    // values must be a non-empty array of parsed item datasets (not [{} empty])
+    expect(Array.isArray(result.values)).toBe(true);
+    expect(result.values.length).toBeGreaterThan(0);
+
+    // the inner item must contain the UDI tag with the correct value
+    const item = result.values[0];
+    const udiTagKey = Object.keys(item).find(
+        k => k.toUpperCase() === "00181009"
+    );
+    expect(udiTagKey).toBeTruthy();
+    // (0018,1009) is VR=UT in the dictionary, so implicit VR parsing returns a string
+    const udiValue = item[udiTagKey].Value[0];
+    expect(udiValue.trimEnd()).toBe(udi);
+});


### PR DESCRIPTION
## Problem

When a DICOM file encodes a sequence element with `VR=UN` and a **defined length** (valid per DICOM PS3.5 §6.2.2), dcmjs fails to parse it correctly.

### Root cause

DICOM PS3.5 §6.2.2 requires that when a sequence is stored with `VR=UN` and a defined length, its items **must** be parsed using **Implicit VR Little Endian**, regardless of the file's overall transfer syntax.

dcmjs did not implement this rule. It attempted to read the item bytes as Explicit VR, encountered `28 00` as the VR string (the character `(` + NUL), emitted `Invalid vr type ( - using UN`, and stored the value as `[{}]`.

### Consequence

On write-back, the corrupt `[{}]` payload caused a ~843 MB length field to be emitted for the element (e.g. files containing `UDISequence (0018,100A)`), inflating an 788 KB file to 843 MB.

## Fix

In `DicomMessage._readTag()`:

1. Record the **wire VR** (`wireVrType`) immediately after `stream.readVR()`, before any dictionary override changes `vrType`.
2. After reading the element length, if `wireVrType === "UN"` and the payload starts with `FE FF` (the little-endian group bytes of the DICOM item-start tag `0xFFFEE000`), promote the element to `SQ` and switch the recursive read to `IMPLICIT_LITTLE_ENDIAN`.

The `wireVrType` approach correctly handles both:
- **Unknown tags** — where `vr.type` stays `"UN"`
- **Known tags** like `UDISequence (0018,100A)` — where the existing dictionary-override already promotes `vrType` to `"SQ"` before our check runs

## Test

Adds a regression test that constructs a hand-crafted Explicit VR Little Endian buffer encoding `UDISequence (0018,100A)` as `VR=UN` with a defined length, containing one Implicit VR item with `UniqueDeviceIdentifier (0018,1009)`. Verifies:
- The element is promoted to `SQ`
- The inner item is a non-empty array (not `[{}]`)
- The UDI string value is correctly recovered