### PR TITLE
fix: fix charset handling in async reader

### DIFF
--- a/src/AsyncDicomReader.js
+++ b/src/AsyncDicomReader.js
@@ -748,6 +748,13 @@ export class AsyncDicomReader {
                     throw Error(`Unsupported character set: ${coding}`);
                 }
             }
+            // Normalize to UTF-8 in the stored value, matching the synchronous
+            // DicomMessage path which always rewrites SpecificCharacterSet to
+            // ISO_IR 192 after decoding (dcmjs always re-encodes output as UTF-8).
+            //
+            // TODO: the original charset value should also be preserved:
+            // it is needed for bulk data decoding.
+            values = ["ISO_IR 192"];
         }
 
         values.forEach(value => listener.value(value));


### PR DESCRIPTION
As I am switching dicom-curate to use the async parser of dcmjs, I was troubleshooting the fact that processed files suddenly had different checksums. I narrowed it down to this discrepancy:

```
-(0008,0005) CS [ISO_IR 192]                             #  10, 1 SpecificCharacterSet
+(0008,0005) CS [ISO_IR 100]                             #  10, 1 SpecificCharacterSet
```

The dcmjs sync parser always outputs ISO_IR 192 (as it re-encodes strings to UTF-8). The async parser also converts strings to UTF-8, but forgets to override the related tag. This PR resolves the difference.