### PR TITLE
fix(sr): avoid injecting options into Template ContentSequences

### DIFF
--- a/src/sr/templates.js
+++ b/src/sr/templates.js
@@ -319,7 +319,7 @@ class MeasurementStatisticalProperties extends Template {
 
 class NormalRangeProperties extends Template {
     constructor(options) {
-        super(options);
+        super();
         if (options.values === undefined) {
             throw new Error(
                 "Option 'values' is required for NormalRangeProperties."
@@ -796,7 +796,7 @@ class SubjectContextSpecimen extends Template {
 
 class SubjectContextDevice extends Template {
     constructor(options) {
-        super(options);
+        super();
         if (options.name === undefined) {
             throw new Error(
                 "Option 'name' is required for SubjectContextDevice."
@@ -1164,7 +1164,7 @@ class VolumetricROIMeasurementsAndQualitativeEvaluations extends _ROIMeasurement
 
 class MeasurementsDerivedFromMultipleROIMeasurements extends Template {
     constructor(options) {
-        super(options);
+        super();
         if (options.derivation === undefined) {
             throw new Error(
                 "Option 'derivation' is required for " +
@@ -1433,7 +1433,7 @@ class MeasurementReport extends Template {
 
 class TimePointContext extends Template {
     constructor(options) {
-        super(options);
+        super();
         if (options.timePoint === undefined) {
             throw new Error(
                 "Option 'timePoint' is required for TimePointContext."
@@ -1588,7 +1588,7 @@ class AlgorithmIdentification extends Template {
 
 class TrackingIdentifier extends Template {
     constructor(options) {
-        super(options);
+        super();
         if (options.uid === undefined) {
             throw new Error("Option 'uid' is required for TrackingIdentifier.");
         }

--- a/test/TrackingIdentifier.test.js
+++ b/test/TrackingIdentifier.test.js
@@ -1,0 +1,26 @@
+import { TrackingIdentifier } from "../src/sr/templates.js";
+
+/**
+ * Regression for https://github.com/dcmjs-org/dcmjs/issues/434 — Template
+ * subclasses must call super(), not super(options), or the options object is
+ * inserted as the first array element (ContentSequence extends Array).
+ */
+describe("TrackingIdentifier", () => {
+    it("contains only DICOM content items, not the raw options object", () => {
+        const id = new TrackingIdentifier({
+            identifier: "ROI #1",
+            uid: "1.2.3.4.5.6.7.8.9"
+        });
+        expect(id).toHaveLength(2);
+        expect(id[0].ValueType).toBe("TEXT");
+        expect(id[1].ValueType).toBe("UIDREF");
+    });
+
+    it("with only uid is a single UIDREF item", () => {
+        const id = new TrackingIdentifier({
+            uid: "1.2.3.4.5.6.7.8.9"
+        });
+        expect(id).toHaveLength(1);
+        expect(id[0].ValueType).toBe("UIDREF");
+    });
+});


### PR DESCRIPTION
## Summary

Fixes SR template classes that incorrectly called `super(options)` where `Template` extends `Array` via `ContentSequence`. Passing a plain options object into `Array` added a non-DICOM element (the raw `{ … }` object) as the first sequence item, which broke downstream validation and produced invalid content sequences.

Closes https://github.com/dcmjs-org/dcmjs/issues/434  
Addresses review feedback on https://github.com/dcmjs-org/dcmjs/pull/435#issuecomment (extend fix to all affected `Template` subclasses).

## Changes

- **`TrackingIdentifier`**: Call `super()` so the sequence contains only the intended `TEXT` (optional) and `UIDREF` items—no injected options object.
- **Same fix for four other `Template` subclasses** that used `super(options)`:
  - `NormalRangeProperties`
  - `SubjectContextDevice`
  - `MeasurementsDerivedFromMultipleROIMeasurements`
  - `TimePointContext`
- **Tests**: Add `test/TrackingIdentifier.test.js` to lock in correct length and value types for `TrackingIdentifier`.

## Why this is safe

The removed first element was never valid DICOM content; callers that spread these instances (`push(...instance)`) now receive only proper content items. Internal repo usage does not rely on the buggy extra element.

## Checklist

- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
